### PR TITLE
fix: patch hardcoded nasiko.dev URLs in web bundle at container startup

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -328,6 +328,14 @@ services:
       AUTH_BASE_URL: ""
       AGENTS_BASE_URL: /agents
       IS_DEVELOPMENT: "false"
+    # The compiled Flutter bundle has https://nasiko.dev hardcoded. Patch it at
+    # startup so local deployments route through Kong instead of the production host.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        KONG_URL="http://localhost:${NASIKO_PORT_KONG:-9100}"
+        sed -i "s|https://nasiko.dev|$$KONG_URL|g" /usr/share/nginx/html/main.dart.js
+        exec /docker-entrypoint.sh nginx -g 'daemon off;'
     networks:
       - app-network
     healthcheck:


### PR DESCRIPTION
## Problem

The compiled Flutter web bundle (`main.dart.js`) has `https://nasiko.dev` hardcoded for all API endpoints:

- `https://nasiko.dev/auth`
- `https://nasiko.dev/api/v1`
- `https://nasiko.dev/router`
- `https://nasiko.dev/agents`

This means anyone running `docker compose -f docker-compose.local.yml up` **cannot log in** — all auth requests go to the production server instead of the local Kong gateway, resulting in `Authentication failed`.

The `.env` asset file and `config.js` (which correctly uses `window.location.origin`) are both ignored because the URLs are baked into the compiled Dart→JS bundle at build time.

## Fix

Override the `nasiko-web` container entrypoint in `docker-compose.local.yml` to run a `sed` patch on `main.dart.js` before nginx starts, replacing `https://nasiko.dev` with `http://localhost:${NASIKO_PORT_KONG:-9100}`.

```yaml
entrypoint: ["/bin/sh", "-c"]
command:
  - |
    KONG_URL="http://localhost:${NASIKO_PORT_KONG:-9100}"
    sed -i "s|https://nasiko.dev|$$KONG_URL|g" /usr/share/nginx/html/main.dart.js
    exec /docker-entrypoint.sh nginx -g 'daemon off;'
```

No rebuild required — works with the existing pre-built image.

## Test

```bash
docker compose -f docker-compose.local.yml --env-file .nasiko-local.env up -d
# navigate to http://localhost:9100 -> login with access key/secret -> success
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)