### PR TITLE
feat: CLI redesign — auth, cluster, context, github, agent, chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # Sensitive credentials
 superuser_credentials.json
+docs/cli-reference.md
+docs/cli-command-design.md
+docs/copy design.md

--- a/cli/auth/auth_commands.py
+++ b/cli/auth/auth_commands.py
@@ -66,10 +66,10 @@ def login_command(
             typer.echo(f"👋 Welcome back, {username} ({role})")
 
         typer.echo("\n🚀 You can now use authenticated commands:")
-        typer.echo("   • nasiko registry-list")
-        typer.echo("   • nasiko upload-zip <file.zip>")
-        typer.echo("   • nasiko status")
-        typer.echo("   • nasiko traces <agent-name>")
+        typer.echo("   • nasiko agent deploy .")
+        typer.echo("   • nasiko agent list")
+        typer.echo("   • nasiko auth status")
+        typer.echo("   • nasiko chat start <agent>")
     else:
         raise typer.Exit(1)
 
@@ -98,121 +98,44 @@ def logout_command(
 
 @auth_app.command("status")
 def status_command():
-    """Check authentication status."""
-
-    auth_manager = get_auth_manager()
-
-    if auth_manager.is_logged_in():
-        typer.echo("✅ Logged in")
-
-        # Try to get user info
-        user_info = auth_manager.get_user_info()
-        if user_info:
-            typer.echo(f"   User: {user_info.get('username', 'Unknown')}")
-            typer.echo(
-                f"   Role: {'Super User' if user_info.get('is_super_user') else 'User'}"
-            )
-            typer.echo(f"   Email: {user_info.get('email', 'Not available')}")
-
-            if user_info.get("last_login"):
-                typer.echo(f"   Last login: {user_info['last_login']}")
-
-        # Test API connectivity
-        try:
-            client = get_api_client()
-            response = client.get("healthcheck", require_auth=False)
-            if response.status_code == 200:
-                typer.echo("   API: ✅ Connected")
-            else:
-                typer.echo("   API: ⚠️  Connection issues")
-        except:
-            typer.echo("   API: ❌ Cannot connect")
-
-    else:
-        typer.echo("❌ Not logged in")
-        typer.echo("\n💡 To login:")
-        typer.echo("   nasiko login")
-
-
-@auth_app.command("whoami")
-def whoami_command():
-    """Show current user information."""
+    """Check authentication status and show current user information."""
 
     auth_manager = get_auth_manager()
 
     if not auth_manager.is_logged_in():
         typer.echo("❌ Not logged in")
-        typer.echo("💡 Use: nasiko login")
-        raise typer.Exit(1)
+        typer.echo("\n💡 To login:")
+        typer.echo("   nasiko auth login")
+        return
+
+    typer.echo("✅ Logged in")
 
     user_info = auth_manager.get_user_info()
+    if user_info:
+        typer.echo(f"   Username: {user_info.get('username', 'Unknown')}")
+        typer.echo(f"   Email: {user_info.get('email', 'Not available')}")
+        typer.echo(
+            f"   Role: {'Super User' if user_info.get('is_super_user') else 'User'}"
+        )
+        typer.echo(f"   Active: {'Yes' if user_info.get('is_active') else 'No'}")
 
-    if not user_info:
-        typer.echo("❌ Could not retrieve user information")
-        typer.echo("💡 Try: nasiko login")
-        raise typer.Exit(1)
+        if user_info.get("created_at"):
+            typer.echo(f"   Created: {user_info['created_at']}")
 
-    # Display user information
-    typer.echo("👤 User Information:")
-    typer.echo(f"   Username: {user_info.get('username', 'Unknown')}")
-    typer.echo(f"   Email: {user_info.get('email', 'Not available')}")
-    typer.echo(f"   Role: {'Super User' if user_info.get('is_super_user') else 'User'}")
-    typer.echo(f"   Active: {'Yes' if user_info.get('is_active') else 'No'}")
+        if user_info.get("last_login"):
+            typer.echo(f"   Last login: {user_info['last_login']}")
 
-    if user_info.get("created_at"):
-        typer.echo(f"   Created: {user_info['created_at']}")
-
-    if user_info.get("last_login"):
-        typer.echo(f"   Last login: {user_info['last_login']}")
-
-
-# Standalone commands for backward compatibility
-def login_standalone(
-    access_key: str = None,
-    access_secret: str = None,
-    save_credentials: bool = True,
-    api_url: str = None,
-):
-    """Standalone login function for backward compatibility"""
-    # Call the actual login_command with proper parameters
-    return _do_login(access_key, access_secret, save_credentials, api_url)
+    # Test API connectivity
+    try:
+        client = get_api_client()
+        response = client.get("healthcheck", require_auth=False)
+        if response.status_code == 200:
+            typer.echo("   API: ✅ Connected")
+        else:
+            typer.echo("   API: ⚠️  Connection issues")
+    except Exception:
+        typer.echo("   API: ❌ Cannot connect")
 
 
-def _do_login(
-    access_key: Optional[str],
-    access_secret: Optional[str],
-    save_credentials: bool = True,
-    api_url: Optional[str] = None,
-):
-    """Internal login function that does the actual work"""
-    # Validate inputs
-    if not access_key or not access_secret:
-        typer.echo("❌ Access key and secret are required")
-        raise typer.Exit(1)
-
-    if not access_key.startswith("NASK_"):
-        typer.echo("❌ Invalid access key format (should start with NASK_)")
-        raise typer.Exit(1)
-
-    # Login with auth manager
-    auth_manager = get_auth_manager()
-    if api_url:
-        auth_manager.auth_url = api_url
-
-    typer.echo("🔐 Authenticating...")
-
-    if auth_manager.login(access_key, access_secret, save_credentials):
-        # Get user info if available
-        user_info = auth_manager.get_user_info()
-        if user_info:
-            username = user_info.get("username", "Unknown")
-            is_super = user_info.get("is_super_user", False)
-            role = "Super User" if is_super else "User"
-            typer.echo(f"👋 Welcome back, {username} ({role})")
-    else:
-        raise typer.Exit(1)
-
-
-# Export for use in main CLI
 if __name__ == "__main__":
     auth_app()

--- a/cli/auth/auth_manager.py
+++ b/cli/auth/auth_manager.py
@@ -51,6 +51,7 @@ class AuthManager:
     def __init__(self, base_url: str = None, cluster_name: str = None):
         self.config_dir = CONFIG_DIR
         self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.cluster_name = cluster_name or os.environ.get("NASIKO_CLUSTER_NAME")
 
         # Determine Base URL
         if base_url:
@@ -83,9 +84,15 @@ class AuthManager:
 
         self.auth_url = self.base_url  # Auth service is at base URL
 
-        # File-based fallback paths
-        self.token_file = self.config_dir / "token.enc"
-        self.creds_file = self.config_dir / "credentials.enc"
+        # Per-cluster storage keys (so each cluster has its own token)
+        cluster_key = self.cluster_name or self.base_url or "default"
+        self.TOKEN_KEY = f"jwt_token_{cluster_key}"
+        self.CREDS_KEY = f"user_creds_{cluster_key}"
+
+        # File-based fallback paths (per-cluster)
+        safe_key = cluster_key.replace("/", "_").replace(":", "_").replace(".", "_")
+        self.token_file = self.config_dir / f"token_{safe_key}.enc"
+        self.creds_file = self.config_dir / f"credentials_{safe_key}.enc"
 
     def _get_encryption_key(self) -> bytes:
         """Generate encryption key from system/user information"""

--- a/cli/auth/auth_manager.py
+++ b/cli/auth/auth_manager.py
@@ -218,7 +218,14 @@ class AuthManager:
             )
 
             if response.status_code == 200:
-                token_data = response.json()
+                try:
+                    token_data = response.json()
+                except Exception:
+                    typer.echo("❌ Auth service returned a non-JSON response.")
+                    typer.echo(f"   URL tried: {login_url}")
+                    typer.echo("   The API URL may be wrong — reconnect with the correct URL:")
+                    typer.echo("   nasiko cluster connect <name> --url <correct-url>")
+                    return False
                 jwt_token = token_data["token"]
 
                 # Store JWT token securely
@@ -287,16 +294,28 @@ class AuthManager:
             return False
 
         try:
-            # Test token with a lightweight API call
-            base_url_str = str(self.base_url)  # Ensure it's a string
-            health_url = f"{base_url_str}/api/v1/healthcheck"
-            response = requests.get(health_url, headers=headers, timeout=10)
+            # Validate token against the auth service
+            token = headers.get("Authorization", "").removeprefix("Bearer ")
+            validate_url = f"{self.base_url}/auth/validate"
+            response = requests.post(
+                validate_url,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=10,
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("valid", False)
 
             if response.status_code == 401:
-                # Try to auto-renew with stored credentials
                 return self._auto_renew_token()
 
-            return response.status_code == 200
+            # Auth service unreachable — fall back to healthcheck so offline usage
+            # doesn't hard-block the user
+            base_url_str = str(self.base_url)
+            health_url = f"{base_url_str}/api/v1/healthcheck"
+            health_response = requests.get(health_url, timeout=10)
+            return health_response.status_code == 200
 
         except Exception:
             return self._auto_renew_token()

--- a/cli/commands/chat_history.py
+++ b/cli/commands/chat_history.py
@@ -15,13 +15,30 @@ from core.api_client import get_api_client
 console = Console()
 
 
+def _get_agent_url(agent_name: str) -> Optional[str]:
+    """Look up agent URL from the registry by name."""
+    try:
+        client = get_api_client()
+        response = client.get(
+            APIEndpoints.REGISTRY_BY_AGENT_NAME.format(agent_name=agent_name),
+            True,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        data = response.json()
+        actual = data.get("data", data)
+        return actual.get("url")
+    except Exception:
+        return None
+
+
 def create_session(agent_name: Optional[str] = None):
     """Create a new chat session."""
 
     try:
         client = get_api_client()
 
-        # Send agent_name wrapped in proper request body structure
         if agent_name:
             response = client.post(
                 APIEndpoints.CHAT_SESSION, data={"agent_id": agent_name}
@@ -48,6 +65,57 @@ def create_session(agent_name: Optional[str] = None):
     except Exception as e:
         console.print(f"[red]Error: {str(e)}[/red]")
         raise typer.Exit(1)
+
+
+def interactive_chat(agent_name: str):
+    """Create a session and enter an interactive chat loop with the agent."""
+    from commands.chat_send import send_message_command_quiet
+
+    # Look up agent URL
+    console.print(f"[dim]Looking up agent '{agent_name}'...[/dim]")
+    agent_url = _get_agent_url(agent_name)
+    if not agent_url:
+        console.print(f"[red]Agent '{agent_name}' not found in registry.[/red]")
+        console.print("Run [bold]nk agent list[/bold] to see available agents.")
+        raise typer.Exit(1)
+
+    # Create session
+    try:
+        client = get_api_client()
+        response = client.post(APIEndpoints.CHAT_SESSION, data={"agent_id": agent_name})
+        result = client.handle_response(response)
+        if result is None:
+            raise typer.Exit(1)
+        data = result.get("data", result)
+        session_id = data.get("session_id")
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Failed to create session: {e}[/red]")
+        raise typer.Exit(1)
+
+    console.print(Panel.fit(
+        f"[bold cyan]Chatting with:[/bold cyan] [green]{agent_name}[/green]\n"
+        f"[dim]Session: {session_id}[/dim]\n"
+        f"[dim]Type 'exit' or press Ctrl+C to quit[/dim]",
+        border_style="cyan",
+    ))
+    console.print()
+
+    while True:
+        try:
+            user_input = console.input("[bold yellow]You:[/bold yellow] ").strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[dim]Goodbye![/dim]")
+            break
+
+        if not user_input:
+            continue
+        if user_input.lower() in ("exit", "quit", "bye"):
+            console.print("[dim]Goodbye![/dim]")
+            break
+
+        send_message_command_quiet(agent_url, user_input, session_id)
 
 
 def list_sessions(

--- a/cli/commands/chat_send.py
+++ b/cli/commands/chat_send.py
@@ -108,6 +108,60 @@ def send_message_command(url: str, message: str, session_id: str):
         console.print(f"[red]Error: {str(e)}[/red]")
 
 
+def send_message_command_quiet(url: str, message: str, session_id: str):
+    """Send a message in interactive mode — no header noise, just the response."""
+    try:
+        auth_manager = get_auth_manager()
+        if not auth_manager.is_logged_in():
+            console.print("[red]Not logged in. Run 'nasiko auth login'.[/red]")
+            raise typer.Exit(1)
+
+        auth_manager.refresh_token_if_needed()
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": session_id,
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": message}],
+                    "messageId": str(uuid.uuid4()),
+                }
+            },
+        }
+
+        headers = {"Content-Type": "application/json"}
+        auth_headers = auth_manager.get_auth_headers()
+        if auth_headers:
+            headers.update(auth_headers)
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[dim]thinking...[/dim]"),
+            console=console,
+            transient=True,
+        ) as progress:
+            progress.add_task("", total=None)
+            response = requests.post(url, json=payload, headers=headers, timeout=60)
+
+        if response.status_code == 200:
+            display_agent_response(response.json())
+        else:
+            console.print(f"[red]Error {response.status_code}:[/red] {response.text}")
+
+    except typer.Exit:
+        raise
+    except requests.exceptions.ConnectionError:
+        console.print(f"[red]Could not connect to agent at {url}[/red]")
+    except requests.exceptions.Timeout:
+        console.print("[red]Request timed out.[/red]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+
+    console.print()
+
+
 def display_agent_response(response_data):
     """Parse and display the agent response - show text from artifacts as the main response."""
 

--- a/cli/commands/chat_send.py
+++ b/cli/commands/chat_send.py
@@ -22,7 +22,7 @@ def send_message_command(url: str, message: str, session_id: str):
         # Get authentication headers
         auth_manager = get_auth_manager()
         if not auth_manager.is_logged_in():
-            console.print("[red]Error: Please login first using 'nasiko login'[/red]")
+            console.print("[red]Error: Please login first using 'nasiko auth login'[/red]")
             raise typer.Exit(1)
 
         if not auth_manager.refresh_token_if_needed():

--- a/cli/commands/cli_docs.py
+++ b/cli/commands/cli_docs.py
@@ -94,15 +94,13 @@ def show_overview():
         ("nasiko auth",          "Login, logout, status"),
         ("nasiko cluster",       "Create, connect, destroy, inspect clusters"),
         ("nasiko github",        "Connect GitHub, clone repos as agents"),
-        ("nasiko agent",         "Deploy and manage AI agents"),
-        ("nasiko chat",          "Create sessions and chat with agents"),
-        ("nasiko observability", "Sessions, traces, spans, stats"),
+        ("nasiko agent",         "Deploy and manage AI agents (incl. nasiko agent n8n)"),
+        ("nasiko chat",          "Interactive chat sessions with agents"),
+        ("nasiko observe",       "Sessions, traces, spans, stats"),
         ("nasiko access",        "Grant / revoke agent permissions"),
+        ("nasiko admin",         "User management + search (super user only)"),
         ("nasiko local",         "Manage local Docker Compose stack"),
-        ("nasiko n8n",           "Connect N8N and register workflows as agents"),
         ("nasiko images",        "Build and push Nasiko core images"),
-        ("nasiko user",          "User management (super user only)"),
-        ("nasiko search",        "Search users and agents"),
     ])
 
     _section("Drill into a topic")
@@ -110,8 +108,8 @@ def show_overview():
     topics = [
         "install", "quickstart", "concepts",
         "auth", "cluster", "github", "agent",
-        "chat", "observability", "access", "local",
-        "n8n", "images", "user", "search", "env",
+        "chat", "observe", "access", "local",
+        "n8n", "images", "admin", "env",
     ]
     console.print("  " + "  ".join(f"[cyan]{t}[/cyan]" for t in topics))
     console.print()
@@ -173,14 +171,18 @@ def show_quickstart():
          "nasiko init\n"
          "  # Cluster type: local\n"
          "  # Cluster name: local  (default)"),
-        ("2", "Find your credentials",
-         "cat orchestrator/superuser_credentials.json"),
-        ("3", "Log in",
+        ("2", "Log in",
          "nasiko auth login\n"
          "  # Access Key:    NASK_xxxx\n"
-         "  # Access Secret: ****"),
-        ("4", "Deploy your first agent",
-         "nasiko agent upload-directory ./my-agent"),
+         "  # Access Secret: ****\n\n"
+         "# If you need to regenerate credentials:\n"
+         "nasiko cluster init-superuser"),
+        ("3", "Deploy your first agent",
+         "nasiko agent deploy ./my-agent\n"
+         "nasiko agent deploy ./my-agent.zip\n"
+         "nasiko agent deploy owner/repo     # from GitHub"),
+        ("4", "Chat with the agent",
+         "nasiko chat start \"My Agent\""),
     ]
     for num, title, code in steps:
         console.print(f" [bold bright_cyan]{num}.[/bold bright_cyan] [bold]{title}[/bold]")
@@ -398,16 +400,27 @@ def show_agent():
 
     _section("Commands")
     _cmd_table([
-        ("nasiko agent upload-directory <path>", "Deploy an agent from a local directory"),
-        ("nasiko agent upload-zip <file>",       "Deploy an agent from a .zip file"),
-        ("nasiko agent list",                    "List all agents in the registry"),
-        ("nasiko agent list-uploaded",           "List agents uploaded by the current user"),
-        ("nasiko agent get",                     "Get detailed info about a specific agent"),
+        ("nasiko agent deploy <source>",   "Smart deploy: directory, .zip, or GitHub owner/repo"),
+        ("nasiko agent list",              "List all agents in the registry"),
+        ("nasiko agent list-uploaded",     "List agents uploaded by the current user"),
+        ("nasiko agent get",               "Get detailed info about a specific agent"),
+        ("nasiko agent n8n",               "N8N sub-group — connect, register workflows as agents"),
+    ])
+
+    _section("nasiko agent deploy — smart routing")
+    _code(
+        "nasiko agent deploy .                  # from current directory\n"
+        "nasiko agent deploy ./my-agent         # from a directory\n"
+        "nasiko agent deploy ./my-agent.zip     # from a zip file\n"
+        "nasiko agent deploy owner/repo         # from GitHub (needs github connect)"
+    )
+    _flags_table([
+        ("--name", "-n", "optional", "Override agent name (auto-detected if omitted)"),
     ])
 
     _section("nasiko agent list — flags")
     _flags_table([
-        ("--format", "-f", "table", "table, json, or list"),
+        ("--format",  "-f", "table", "table, json, or list"),
         ("--details", "-d", "false", "Show additional details"),
     ])
 
@@ -418,12 +431,25 @@ def show_agent():
         ("--format",   "-f", "details",  "details or json"),
     ])
 
+    _section("N8N sub-group")
+    _cmd_table([
+        ("nasiko agent n8n connect",               "Save N8N credentials (--url, --api-key, --connection-name)"),
+        ("nasiko agent n8n credentials",           "View saved N8N credentials"),
+        ("nasiko agent n8n update",                "Update credentials (--name, --url, --api-key, --active)"),
+        ("nasiko agent n8n disconnect",            "Remove N8N credentials permanently"),
+        ("nasiko agent n8n workflows",             "List workflows (--active-only, --limit/-l 100)"),
+        ("nasiko agent n8n register <workflow_id>","Register workflow as agent (--name/-n, --description/-d)"),
+    ])
+
     _section("Example")
     _code(
-        "nasiko agent upload-directory ./agents/my-agent\n"
+        "nasiko agent deploy .\n"
         "nasiko agent list\n"
-        "nasiko agent list --format json\n"
-        "nasiko agent get --name my-agent"
+        "nasiko agent get --name \"Translator Agent\"\n\n"
+        "# Deploy from N8N\n"
+        "nasiko agent n8n connect --url http://n8n.example.com --api-key <key> --connection-name prod\n"
+        "nasiko agent n8n workflows\n"
+        "nasiko agent n8n register <workflow_id> --name my-workflow-agent"
     )
 
 
@@ -436,11 +462,30 @@ def show_chat():
 
     _section("Commands")
     _cmd_table([
-        ("nasiko chat create-session",          "Create a new chat session (--agent/-a for agent name)"),
-        ("nasiko chat list-sessions",           "List sessions (--limit/-l, --cursor, --direction)"),
-        ("nasiko chat history <session_id>",    "View conversation history"),
-        ("nasiko chat delete-session <id>",     "Delete a session"),
-        ("nasiko chat send",                    "Send a one-shot message (--url/-u, --session-id/-s, --message/-m)"),
+        ("nasiko chat start <agent>",        "Interactive chat loop — type messages, get replies, Ctrl+C to quit"),
+        ("nasiko chat send",                 "One-shot message (--url/-u, --session-id/-s, --message/-m)"),
+        ("nasiko chat sessions",             "List sessions (--limit/-l, --cursor, --direction)"),
+        ("nasiko chat history <session_id>", "View conversation history"),
+        ("nasiko chat drop <session_id>",    "Delete a session"),
+    ])
+
+    _section("Interactive chat (recommended)")
+    _code(
+        "nasiko chat start \"Translator Agent\"\n\n"
+        "# ╭─────────────────────────────────╮\n"
+        "# │ Chatting with: Translator Agent │\n"
+        "# │ Type 'exit' or Ctrl+C to quit   │\n"
+        "# ╰─────────────────────────────────╯\n\n"
+        "# You: Translate to French: Hello world\n"
+        "# Agent Reply: Bonjour le monde\n\n"
+        "# You: exit"
+    )
+
+    _section("One-shot send")
+    _flags_table([
+        ("--url",        "-u", "required", "Agent URL (from nasiko agent get --name <agent>)"),
+        ("--session-id", "-s", "required", "Session ID"),
+        ("--message",    "-m", "required", "Message to send"),
     ])
 
 
@@ -448,16 +493,16 @@ def show_chat():
 # OBSERVABILITY
 # ─────────────────────────────────────────────────────────
 
-def show_observability():
-    _header("nasiko observability", "Monitor sessions, traces, and agent performance")
+def show_observe():
+    _header("nasiko observe", "Monitor sessions, traces, and agent performance")
 
     _section("Commands")
     _cmd_table([
-        ("nasiko observability sessions [agent_id]",         "Recent sessions, optionally filtered by agent"),
-        ("nasiko observability session <session_id>",        "Full details for one session"),
-        ("nasiko observability trace <project_id> <trace_id>", "Trace with nested spans"),
-        ("nasiko observability span <span_id>",              "Individual span details"),
-        ("nasiko observability stats <agent_id>",            "Performance stats for an agent"),
+        ("nasiko observe sessions [agent_id]",            "Recent sessions, optionally filtered by agent"),
+        ("nasiko observe session <session_id>",           "Full details for one session"),
+        ("nasiko observe trace <project_id> <trace_id>", "Trace with nested spans"),
+        ("nasiko observe span <span_id>",                 "Individual span details"),
+        ("nasiko observe stats <agent_id>",               "Performance stats for an agent"),
     ])
 
     _section("Common flags")
@@ -477,12 +522,24 @@ def show_access():
 
     _section("Commands")
     _cmd_table([
-        ("nasiko access grant-user <agent_id>",   "Grant user(s) access  (--user-id/-u, repeatable)"),
-        ("nasiko access grant-agent <agent_id>",  "Grant agent-to-agent access  (--agent-id/-a, repeatable)"),
-        ("nasiko access list <agent_id>",         "Show current permissions"),
-        ("nasiko access revoke-user <agent_id>",  "Revoke user access"),
-        ("nasiko access revoke-agent <agent_id>", "Revoke agent-to-agent access"),
+        ("nasiko access grant <agent_id>",  "Grant access — use --user/-u or --agent/-a (repeatable)"),
+        ("nasiko access revoke <agent_id>", "Revoke access — same flags"),
+        ("nasiko access list <agent_id>",   "Show current permissions"),
     ])
+
+    _section("nasiko access grant / revoke — flags")
+    _flags_table([
+        ("--user",  "-u", "optional", "User ID(s) to grant/revoke access (repeatable)"),
+        ("--agent", "-a", "optional", "Agent ID(s) to grant/revoke access (repeatable)"),
+    ])
+
+    _section("Example")
+    _code(
+        "nasiko access grant  my-agent-id --user user-123 --user user-456\n"
+        "nasiko access grant  my-agent-id --agent other-agent-id\n"
+        "nasiko access revoke my-agent-id --user user-123\n"
+        "nasiko access list   my-agent-id"
+    )
 
 
 # ─────────────────────────────────────────────────────────
@@ -524,23 +581,28 @@ def show_local():
 # ─────────────────────────────────────────────────────────
 
 def show_n8n():
-    _header("nasiko n8n", "Connect N8N and register workflows as agents")
+    _header("nasiko agent n8n", "Connect N8N and register workflows as agents")
+
+    console.print(
+        "\n[dim]N8N commands live under[/dim] [cyan]nasiko agent n8n[/cyan][dim].\n"
+        "Run[/dim] [cyan]nasiko docs agent[/cyan] [dim]for the full agent + n8n reference.[/dim]\n"
+    )
 
     _section("Commands")
     _cmd_table([
-        ("nasiko n8n connect",              "Save N8N credentials (--url, --api-key, --connection-name — all required)"),
-        ("nasiko n8n credentials",          "View saved N8N credentials"),
-        ("nasiko n8n update",               "Update credentials (--name, --url, --api-key, --active)"),
-        ("nasiko n8n delete",               "Remove credentials permanently"),
-        ("nasiko n8n workflows",            "List workflows (--active-only, --limit/-l 100)"),
-        ("nasiko n8n register <workflow_id>", "Register workflow as agent (--name/-n, --description/-d)"),
+        ("nasiko agent n8n connect",               "Save N8N credentials (--url, --api-key, --connection-name)"),
+        ("nasiko agent n8n credentials",           "View saved N8N credentials"),
+        ("nasiko agent n8n update",                "Update credentials (--name, --url, --api-key, --active)"),
+        ("nasiko agent n8n disconnect",            "Remove credentials permanently"),
+        ("nasiko agent n8n workflows",             "List workflows (--active-only, --limit/-l 100)"),
+        ("nasiko agent n8n register <workflow_id>","Register workflow as agent (--name/-n, --description/-d)"),
     ])
 
     _section("Example flow")
     _code(
-        "nasiko n8n connect --url http://n8n.example.com --api-key <key> --connection-name prod\n"
-        "nasiko n8n workflows              # find your workflow ID\n"
-        "nasiko n8n register <id> --name my-workflow-agent"
+        "nasiko agent n8n connect --url http://n8n.example.com --api-key <key> --connection-name prod\n"
+        "nasiko agent n8n workflows              # find your workflow ID\n"
+        "nasiko agent n8n register <id> --name my-workflow-agent"
     )
 
 
@@ -575,32 +637,24 @@ def show_images():
 # USER
 # ─────────────────────────────────────────────────────────
 
-def show_user():
-    _header("nasiko user", "User management — super user access required")
+def show_admin():
+    _header("nasiko admin", "User management + search — super user access required")
 
-    _section("Commands")
+    _section("User commands")
     _cmd_table([
-        ("nasiko user register",                     "Register a new user (--username/-u, --email/-e, --super-user/-s)"),
-        ("nasiko user list",                         "List all users (--limit/-l, default 50)"),
-        ("nasiko user get <user_id>",                "Get user details"),
-        ("nasiko user regenerate-credentials <id>",  "Reset credentials for a user"),
-        ("nasiko user revoke <user_id>",             "Revoke all tokens"),
-        ("nasiko user reinstate <user_id>",          "Re-enable a revoked user"),
-        ("nasiko user delete <user_id>",             "Permanently delete a user (--confirm skips prompt)"),
+        ("nasiko admin user register",                    "Register a new user (--username/-u, --email/-e, --super-user/-s)"),
+        ("nasiko admin user list",                        "List all users (--limit/-l, default 50)"),
+        ("nasiko admin user get <user_id>",               "Get user details"),
+        ("nasiko admin user reset-creds <user_id>",       "Regenerate credentials for a user"),
+        ("nasiko admin user revoke <user_id>",            "Revoke all tokens for a user"),
+        ("nasiko admin user reinstate <user_id>",         "Re-enable a revoked user"),
+        ("nasiko admin user delete <user_id>",            "Permanently delete (--confirm skips prompt)"),
     ])
 
-
-# ─────────────────────────────────────────────────────────
-# SEARCH
-# ─────────────────────────────────────────────────────────
-
-def show_search():
-    _header("nasiko search", "Search users and agents")
-
-    _section("Commands")
+    _section("Search commands")
     _cmd_table([
-        ("nasiko search users <query>",  "Search users (min 2 chars, --limit/-l max 50)"),
-        ("nasiko search agents <query>", "Search agents (same flags)"),
+        ("nasiko admin search users <query>",  "Search users (min 2 chars, --limit/-l max 50)"),
+        ("nasiko admin search agents <query>", "Search agents (same flags)"),
     ])
 
 
@@ -687,13 +741,13 @@ TOPICS = {
     "github":        show_github,
     "agent":         show_agent,
     "chat":          show_chat,
-    "observability": show_observability,
+    "observe":       show_observe,
+    "observability": show_observe,   # backward compat alias
     "access":        show_access,
+    "admin":         show_admin,
     "local":         show_local,
     "n8n":           show_n8n,
     "images":        show_images,
-    "user":          show_user,
-    "search":        show_search,
     "env":           show_env,
 }
 

--- a/cli/commands/cli_docs.py
+++ b/cli/commands/cli_docs.py
@@ -1,0 +1,712 @@
+"""
+CLI documentation renderer for `nasiko docs`.
+Displays rich terminal documentation for all CLI commands.
+"""
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.rule import Rule
+from rich.columns import Columns
+from rich.text import Text
+from rich import box
+
+console = Console()
+
+
+# ─────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────
+
+def _header(title: str, subtitle: str = ""):
+    console.print()
+    console.print(Panel(
+        f"[bold white]{title}[/bold white]\n[dim]{subtitle}[/dim]" if subtitle else f"[bold white]{title}[/bold white]",
+        border_style="bright_blue",
+        padding=(0, 2),
+    ))
+
+
+def _section(title: str):
+    console.print()
+    console.print(Rule(f"[bold cyan]{title}[/bold cyan]", style="dim"))
+    console.print()
+
+
+def _cmd_table(rows: list[tuple], headers=("Command", "Description")):
+    """Render a command table. rows = [(cmd, desc), ...]"""
+    t = Table(box=box.SIMPLE_HEAD, show_header=True, header_style="bold magenta",
+              show_edge=False, pad_edge=False)
+    for h in headers:
+        t.add_column(h, style="cyan" if h == headers[0] else "white")
+    for row in rows:
+        t.add_row(*row)
+    console.print(t)
+
+
+def _flags_table(rows: list[tuple]):
+    """rows = [(flag, short, required/default, description)]"""
+    t = Table(box=box.SIMPLE_HEAD, show_header=True, header_style="bold magenta",
+              show_edge=False, pad_edge=False)
+    t.add_column("Flag", style="cyan", no_wrap=True)
+    t.add_column("Short", style="yellow", no_wrap=True)
+    t.add_column("Default/Required", no_wrap=True)
+    t.add_column("Description", style="white")
+    for flag, short, req, desc in rows:
+        req_styled = (
+            "[bold red]required[/bold red]" if req == "required"
+            else f"[dim]{req}[/dim]"
+        )
+        t.add_row(flag, short, req_styled, desc)
+    console.print(t)
+
+
+def _code(text: str):
+    console.print(Panel(text, border_style="dim", padding=(0, 2)))
+
+
+def _tip(text: str):
+    console.print(f"\n[bold yellow]💡  Tip:[/bold yellow] {text}\n")
+
+
+# ─────────────────────────────────────────────────────────
+# OVERVIEW
+# ─────────────────────────────────────────────────────────
+
+def show_overview():
+    console.print(Panel(
+        "[bold bright_cyan]Nasiko CLI  v2.0.0[/bold bright_cyan]\n\n"
+        "Build, deploy, and manage AI agents from your terminal.\n"
+        "Run agents locally with Docker or deploy to AWS / DigitalOcean\n"
+        "with a single command.\n\n"
+        "[dim]Think of it like[/dim] [bold]git[/bold][dim] — you have clusters (remotes)\n"
+        "and an active cluster (checked-out branch).[/dim]",
+        title="[bold]nasiko docs[/bold]",
+        border_style="bright_cyan",
+        padding=(1, 4),
+    ))
+
+    _section("Command Groups")
+    _cmd_table([
+        ("nasiko init",          "First-run wizard — create cluster, set active, log in"),
+        ("nasiko use <cluster>", "Switch active cluster"),
+        ("nasiko current",       "Show active cluster + auth state"),
+        ("nasiko auth",          "Login, logout, status"),
+        ("nasiko cluster",       "Create, connect, destroy, inspect clusters"),
+        ("nasiko github",        "Connect GitHub, clone repos as agents"),
+        ("nasiko agent",         "Deploy and manage AI agents"),
+        ("nasiko chat",          "Create sessions and chat with agents"),
+        ("nasiko observability", "Sessions, traces, spans, stats"),
+        ("nasiko access",        "Grant / revoke agent permissions"),
+        ("nasiko local",         "Manage local Docker Compose stack"),
+        ("nasiko n8n",           "Connect N8N and register workflows as agents"),
+        ("nasiko images",        "Build and push Nasiko core images"),
+        ("nasiko user",          "User management (super user only)"),
+        ("nasiko search",        "Search users and agents"),
+    ])
+
+    _section("Drill into a topic")
+    console.print("[dim]Usage:[/dim]  [cyan]nasiko docs <topic>[/cyan]\n")
+    topics = [
+        "install", "quickstart", "concepts",
+        "auth", "cluster", "github", "agent",
+        "chat", "observability", "access", "local",
+        "n8n", "images", "user", "search", "env",
+    ]
+    console.print("  " + "  ".join(f"[cyan]{t}[/cyan]" for t in topics))
+    console.print()
+
+
+# ─────────────────────────────────────────────────────────
+# INSTALL
+# ─────────────────────────────────────────────────────────
+
+def show_install():
+    _header("Installation", "Get the Nasiko CLI on your machine")
+
+    _section("Install via pip")
+    _code("pip install nasiko-cli")
+
+    _section("Recommended — use a virtual environment")
+    _code(
+        "python -m venv .venv\n"
+        "source .venv/bin/activate     # macOS / Linux\n"
+        ".venv\\Scripts\\activate        # Windows\n"
+        "pip install nasiko-cli"
+    )
+
+    _section("Verify")
+    _code("nasiko --version\n# Nasiko CLI v2.0.0")
+
+    _section("Prerequisites")
+
+    console.print("[bold]All setups[/bold]")
+    _flags_table([
+        ("Python", "", "3.10+", "Runtime for the CLI"),
+        ("pip",    "", "any",   "Package manager"),
+    ])
+
+    console.print("\n[bold]Local setup (Docker Compose)[/bold]")
+    _flags_table([
+        ("Docker Desktop / Docker Engine", "", "required", "docker --version"),
+        ("Docker Compose v2",              "", "required", "docker compose version"),
+    ])
+
+    console.print("\n[bold]Remote setup (AWS / DigitalOcean)[/bold]")
+    _flags_table([
+        ("terraform", "", "≥ 1.3",    "terraform -v"),
+        ("kubectl",   "", "required", "kubectl version --client"),
+        ("AWS or DO credentials", "", "required", "See nasiko docs env"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# QUICK START
+# ─────────────────────────────────────────────────────────
+
+def show_quickstart():
+    _header("Quick Start", "From zero to running agents")
+
+    _section("Option A — Local (Docker Compose)  [recommended for first-timers]")
+    steps = [
+        ("1", "Run the setup wizard",
+         "nasiko init\n"
+         "  # Cluster type: local\n"
+         "  # Cluster name: local  (default)"),
+        ("2", "Find your credentials",
+         "cat orchestrator/superuser_credentials.json"),
+        ("3", "Log in",
+         "nasiko auth login\n"
+         "  # Access Key:    NASK_xxxx\n"
+         "  # Access Secret: ****"),
+        ("4", "Deploy your first agent",
+         "nasiko agent upload-directory ./my-agent"),
+    ]
+    for num, title, code in steps:
+        console.print(f" [bold bright_cyan]{num}.[/bold bright_cyan] [bold]{title}[/bold]")
+        _code(code)
+
+    _section("Option B — Remote (AWS)")
+    steps_b = [
+        ("1", "Set AWS credentials",
+         "export AWS_ACCESS_KEY_ID=AKIA...\n"
+         "export AWS_SECRET_ACCESS_KEY=...\n"
+         "export AWS_DEFAULT_REGION=us-east-1"),
+        ("2", "Run the wizard",
+         "nasiko init\n"
+         "  # Cluster type: remote\n"
+         "  # Cloud provider: aws\n"
+         "  # Cluster name: my-nasiko\n"
+         "  # Region: us-east-1"),
+        ("3", "Confirm it's up",
+         "nasiko current"),
+    ]
+    for num, title, code in steps_b:
+        console.print(f" [bold bright_cyan]{num}.[/bold bright_cyan] [bold]{title}[/bold]")
+        _code(code)
+
+    _section("Option C — Connect to existing cluster")
+    _code(
+        "nasiko cluster connect prod --url https://api.my-cluster.example.com\n"
+        "nasiko auth login"
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# CONCEPTS
+# ─────────────────────────────────────────────────────────
+
+def show_concepts():
+    _header("Core Concepts", "How the CLI is designed")
+
+    console.print(
+        "\n[bold]Active cluster[/bold]\n"
+        "Every command targets the active cluster. Set it with [cyan]nasiko use <name>[/cyan].\n"
+        "Override for a single command with [cyan]--cluster / -n[/cyan].\n"
+    )
+    _code(
+        "nasiko use local\n"
+        "nasiko agent list           # runs on local\n"
+        "nasiko agent list -n prod   # runs on prod without switching"
+    )
+
+    console.print(
+        "\n[bold]Auth is per-cluster[/bold]\n"
+        "Logging into [cyan]local[/cyan] does not log you into [cyan]prod-aws[/cyan].\n"
+        "Each cluster has its own auth session.\n"
+    )
+
+    console.print(
+        "\n[bold]State is stored locally[/bold]\n"
+        "  [dim]~/.nasiko/context.json[/dim]       — active cluster\n"
+        "  [dim]~/.nasiko/state/<provider>/<name>/[/dim]  — cluster info, Terraform state, credentials\n"
+    )
+
+    _section("Config file auto-detection (first match wins)")
+    _cmd_table([
+        (".nasiko-local.env", "Local overrides — highest priority"),
+        (".nasiko.env",       "Project config"),
+        (".nasiko-aws.env",   "AWS-specific config"),
+        (".nasiko-do.env",    "DigitalOcean-specific config"),
+        (".env",              "Generic fallback"),
+    ], ("File", "Purpose"))
+
+
+# ─────────────────────────────────────────────────────────
+# AUTH
+# ─────────────────────────────────────────────────────────
+
+def show_auth():
+    _header("nasiko auth", "Authentication — per-cluster")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko auth login",   "Authenticate to the active cluster. Prompts if no flags given."),
+        ("nasiko auth logout",  "Clear your session for the active cluster."),
+        ("nasiko auth status",  "Show auth state, user info, and API connectivity."),
+    ])
+
+    _section("nasiko auth login — flags")
+    _flags_table([
+        ("--access-key",    "-k", "required", "Access key (starts with NASK_)"),
+        ("--access-secret", "-s", "required", "Access secret (hidden input)"),
+        ("--api-url",       "",   "optional", "Override the API URL for this login"),
+    ])
+
+    _section("Example")
+    _code(
+        "nasiko auth login\n"
+        "nasiko auth login -k NASK_xxx -s mysecret\n"
+        "nasiko auth status"
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# CLUSTER
+# ─────────────────────────────────────────────────────────
+
+def show_cluster():
+    _header("nasiko cluster", "Cluster lifecycle — create, connect, inspect, destroy")
+
+    _section("Commands overview")
+    _cmd_table([
+        ("nasiko cluster connect <name> --url <url>", "Register an existing cluster by API URL"),
+        ("nasiko cluster create local",               "Start Docker Compose, register as local cluster"),
+        ("nasiko cluster create remote",              "Provision K8s on AWS/DO via Terraform"),
+        ("nasiko cluster bootstrap",                  "All-in-one: k8s + registry + buildkit + core"),
+        ("nasiko cluster list",                       "List all clusters in local state"),
+        ("nasiko cluster destroy <name>",             "Tear down a cluster"),
+        ("nasiko cluster output",                     "Show Terraform outputs (IPs, kubeconfig)"),
+        ("nasiko cluster state-info",                 "Terraform state details"),
+        ("nasiko cluster init-modules",               "Copy Terraform modules to ~/.nasiko/terraform/"),
+        ("nasiko cluster setup registry harbor",      "Deploy Harbor container registry via Helm"),
+        ("nasiko cluster setup registry cloud",       "Setup ECR (AWS) or DO container registry"),
+        ("nasiko cluster setup buildkit",             "Deploy rootless BuildKit"),
+        ("nasiko cluster setup core",                 "Deploy backend, web, router, auth + infra"),
+        ("nasiko cluster configure-github-oauth",     "Patch GitHub OAuth vars without re-bootstrap"),
+        ("nasiko cluster cleanup",                    "Remove all Nasiko resources from cluster"),
+        ("nasiko cluster init-superuser",             "Create/recreate superuser credentials"),
+        ("nasiko cluster get-superuser",              "Fetch existing superuser credentials"),
+    ])
+
+    _section("nasiko cluster connect — flags")
+    _flags_table([
+        ("<name>",             "",   "required", "Name to give this cluster locally"),
+        ("--url",              "-u", "required", "API gateway URL (https://...)"),
+        ("--login/--no-login", "",   "true",     "Prompt for login after connecting"),
+    ])
+
+    _section("nasiko cluster create remote — flags")
+    _flags_table([
+        ("--provider",      "",   "required",          "aws or digitalocean"),
+        ("--name",          "-n", "nasiko",             "Cluster name"),
+        ("--region",        "",   "optional",           "e.g. us-east-1, nyc3"),
+        ("--node-size",     "",   "optional",           "e.g. t3.medium, s-2vcpu-4gb"),
+        ("--yes",           "-y", "false",              "Auto-approve Terraform apply"),
+        ("--verbose",       "-v", "false",              "Show full Terraform output"),
+        ("--terraform-dir", "-t", "~/.nasiko/terraform","Terraform modules path"),
+        ("--state-dir",     "-s", "~/.nasiko/state",    "Terraform state path"),
+    ])
+
+    _section("Example")
+    _code(
+        "# Connect to existing cluster\n"
+        "nasiko cluster connect prod --url https://api.my-cluster.example.com\n\n"
+        "# Create local Docker stack\n"
+        "nasiko cluster create local\n\n"
+        "# Provision on AWS\n"
+        "nasiko cluster create remote --provider aws --name prod --region us-east-1\n\n"
+        "# All-in-one\n"
+        "nasiko cluster bootstrap --provider aws --cluster-name prod"
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# GITHUB
+# ─────────────────────────────────────────────────────────
+
+def show_github():
+    _header("nasiko github", "GitHub integration — per-cluster")
+
+    console.print(
+        "\n[bold yellow]⚠  Prerequisite:[/bold yellow] GitHub integration requires a GitHub OAuth App\n"
+        "   configured on the cluster. Run [cyan]nasiko github connect[/cyan] — if it's not\n"
+        "   configured yet, you'll see step-by-step setup instructions.\n"
+    )
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko github connect",        "Link GitHub. Prints status if already connected. Guides setup if not configured."),
+        ("nasiko github disconnect",     "Unlink GitHub from this cluster"),
+        ("nasiko github status",         "Show GitHub connection state"),
+        ("nasiko github repos",          "List your accessible GitHub repositories"),
+        ("nasiko github clone [repo]",   "Clone a repo and deploy it as an agent (interactive if repo omitted)"),
+    ])
+
+    _section("nasiko github clone — flags")
+    _flags_table([
+        ("[repo]", "",   "optional", "owner/repo or full GitHub URL. Shows list if omitted."),
+        ("--branch", "-b", "main",  "Branch to clone"),
+    ])
+
+    _section("Example")
+    _code(
+        "nasiko github connect\n"
+        "nasiko github repos\n"
+        "nasiko github clone owner/my-agent-repo\n"
+        "nasiko github clone                    # interactive list"
+    )
+
+    _section("GitHub OAuth setup steps")
+    steps = [
+        "Go to [cyan]https://github.com/settings/developers[/cyan] → OAuth Apps → New OAuth App",
+        "Set Homepage URL and Callback URL to your cluster's API URL\n"
+        "   e.g. Homepage: [cyan]http://localhost:9100[/cyan]   Callback: [cyan]http://localhost:9100/auth/github/callback[/cyan]",
+        "Add to your env file:\n   GITHUB_CLIENT_ID=your_id\n   GITHUB_CLIENT_SECRET=your_secret",
+        "Restart the stack:  [cyan]nasiko local down && nasiko local up[/cyan]",
+    ]
+    for i, s in enumerate(steps, 1):
+        console.print(f" [bold bright_cyan]{i}.[/bold bright_cyan] {s}\n")
+
+
+# ─────────────────────────────────────────────────────────
+# AGENT
+# ─────────────────────────────────────────────────────────
+
+def show_agent():
+    _header("nasiko agent", "Deploy and manage AI agents")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko agent upload-directory <path>", "Deploy an agent from a local directory"),
+        ("nasiko agent upload-zip <file>",       "Deploy an agent from a .zip file"),
+        ("nasiko agent list",                    "List all agents in the registry"),
+        ("nasiko agent list-uploaded",           "List agents uploaded by the current user"),
+        ("nasiko agent get",                     "Get detailed info about a specific agent"),
+    ])
+
+    _section("nasiko agent list — flags")
+    _flags_table([
+        ("--format", "-f", "table", "table, json, or list"),
+        ("--details", "-d", "false", "Show additional details"),
+    ])
+
+    _section("nasiko agent get — flags")
+    _flags_table([
+        ("--agent-id", "",   "optional", "Look up by agent ID (one of --agent-id or --name required)"),
+        ("--name",     "",   "optional", "Look up by agent name"),
+        ("--format",   "-f", "details",  "details or json"),
+    ])
+
+    _section("Example")
+    _code(
+        "nasiko agent upload-directory ./agents/my-agent\n"
+        "nasiko agent list\n"
+        "nasiko agent list --format json\n"
+        "nasiko agent get --name my-agent"
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# CHAT
+# ─────────────────────────────────────────────────────────
+
+def show_chat():
+    _header("nasiko chat", "Chat sessions with deployed agents")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko chat create-session",          "Create a new chat session (--agent/-a for agent name)"),
+        ("nasiko chat list-sessions",           "List sessions (--limit/-l, --cursor, --direction)"),
+        ("nasiko chat history <session_id>",    "View conversation history"),
+        ("nasiko chat delete-session <id>",     "Delete a session"),
+        ("nasiko chat send",                    "Send a one-shot message (--url/-u, --session-id/-s, --message/-m)"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# OBSERVABILITY
+# ─────────────────────────────────────────────────────────
+
+def show_observability():
+    _header("nasiko observability", "Monitor sessions, traces, and agent performance")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko observability sessions [agent_id]",         "Recent sessions, optionally filtered by agent"),
+        ("nasiko observability session <session_id>",        "Full details for one session"),
+        ("nasiko observability trace <project_id> <trace_id>", "Trace with nested spans"),
+        ("nasiko observability span <span_id>",              "Individual span details"),
+        ("nasiko observability stats <agent_id>",            "Performance stats for an agent"),
+    ])
+
+    _section("Common flags")
+    _flags_table([
+        ("--days",   "-d", "7",       "Days to look back"),
+        ("--limit",  "-l", "20",      "Max results"),
+        ("--format", "-f", "table",   "table, json, summary, detailed, tree, spans, traces"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# ACCESS
+# ─────────────────────────────────────────────────────────
+
+def show_access():
+    _header("nasiko access", "Control who can access an agent")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko access grant-user <agent_id>",   "Grant user(s) access  (--user-id/-u, repeatable)"),
+        ("nasiko access grant-agent <agent_id>",  "Grant agent-to-agent access  (--agent-id/-a, repeatable)"),
+        ("nasiko access list <agent_id>",         "Show current permissions"),
+        ("nasiko access revoke-user <agent_id>",  "Revoke user access"),
+        ("nasiko access revoke-agent <agent_id>", "Revoke agent-to-agent access"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# LOCAL
+# ─────────────────────────────────────────────────────────
+
+def show_local():
+    _header("nasiko local", "Manage the local Docker Compose development stack")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko local up",                      "Start the full stack. Checks port conflicts first."),
+        ("nasiko local down",                    "Stop and remove the stack (--volumes/-v deletes all data)"),
+        ("nasiko local status",                  "Show running containers"),
+        ("nasiko local logs [service...]",       "View logs (--follow/-f, --lines/-n 100)"),
+        ("nasiko local restart [service]",       "Restart one or all services"),
+        ("nasiko local shell <service>",         "Open bash in a running container"),
+        ("nasiko local deploy-agent <name> [path]", "Deploy agent to local stack via backend API"),
+    ])
+
+    _section("Services & ports")
+    _cmd_table([
+        ("Kong Gateway",     "9100  ← use as NASIKO_API_URL"),
+        ("Backend API",      "8000  /docs for Swagger"),
+        ("Auth Service",     "8082"),
+        ("Router",           "8081"),
+        ("Chat History",     "8083"),
+        ("Web UI",           "4000"),
+        ("Konga (Kong UI)",  "1337"),
+        ("MongoDB",          "27017"),
+        ("Redis",            "6379"),
+    ], ("Service", "Port / Notes"))
+
+    _tip("All ports can be overridden via NASIKO_PORT_* env vars. Run [cyan]nasiko docs env[/cyan] for the full list.")
+
+
+# ─────────────────────────────────────────────────────────
+# N8N
+# ─────────────────────────────────────────────────────────
+
+def show_n8n():
+    _header("nasiko n8n", "Connect N8N and register workflows as agents")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko n8n connect",              "Save N8N credentials (--url, --api-key, --connection-name — all required)"),
+        ("nasiko n8n credentials",          "View saved N8N credentials"),
+        ("nasiko n8n update",               "Update credentials (--name, --url, --api-key, --active)"),
+        ("nasiko n8n delete",               "Remove credentials permanently"),
+        ("nasiko n8n workflows",            "List workflows (--active-only, --limit/-l 100)"),
+        ("nasiko n8n register <workflow_id>", "Register workflow as agent (--name/-n, --description/-d)"),
+    ])
+
+    _section("Example flow")
+    _code(
+        "nasiko n8n connect --url http://n8n.example.com --api-key <key> --connection-name prod\n"
+        "nasiko n8n workflows              # find your workflow ID\n"
+        "nasiko n8n register <id> --name my-workflow-agent"
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# IMAGES
+# ─────────────────────────────────────────────────────────
+
+def show_images():
+    _header("nasiko images", "Build and push Nasiko core Docker images")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko images list",       "List all 9 core services with their Dockerfiles"),
+        ("nasiko images build",      "Build images locally"),
+        ("nasiko images push",       "Push images to a registry"),
+        ("nasiko images build-push", "Build and push in one command"),
+    ])
+
+    _section("Shared flags (build / push / build-push)")
+    _flags_table([
+        ("--username",       "-u", "karannasiko",  "Registry namespace (Docker Hub)"),
+        ("--tag",            "-t", "latest",       "Image tag"),
+        ("--service",        "-s", "all services", "Specific service(s), repeatable"),
+        ("--platform",       "",   "linux/amd64",  "Target platform(s)"),
+        ("--multi-platform", "",   "false",        "Build for amd64 + arm64"),
+        ("--no-cache",       "",   "false",        "Build without Docker cache"),
+        ("--dry-run",        "",   "false",        "Print commands without running"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# USER
+# ─────────────────────────────────────────────────────────
+
+def show_user():
+    _header("nasiko user", "User management — super user access required")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko user register",                     "Register a new user (--username/-u, --email/-e, --super-user/-s)"),
+        ("nasiko user list",                         "List all users (--limit/-l, default 50)"),
+        ("nasiko user get <user_id>",                "Get user details"),
+        ("nasiko user regenerate-credentials <id>",  "Reset credentials for a user"),
+        ("nasiko user revoke <user_id>",             "Revoke all tokens"),
+        ("nasiko user reinstate <user_id>",          "Re-enable a revoked user"),
+        ("nasiko user delete <user_id>",             "Permanently delete a user (--confirm skips prompt)"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# SEARCH
+# ─────────────────────────────────────────────────────────
+
+def show_search():
+    _header("nasiko search", "Search users and agents")
+
+    _section("Commands")
+    _cmd_table([
+        ("nasiko search users <query>",  "Search users (min 2 chars, --limit/-l max 50)"),
+        ("nasiko search agents <query>", "Search agents (same flags)"),
+    ])
+
+
+# ─────────────────────────────────────────────────────────
+# ENV VARS
+# ─────────────────────────────────────────────────────────
+
+def show_env():
+    _header("Environment Variables", "Configure the CLI without flags")
+
+    _section("Core")
+    _cmd_table([
+        ("NASIKO_API_URL",        "Override the API base URL (bypasses cluster lookup)"),
+        ("NASIKO_CLUSTER_NAME",   "Active cluster name (set by nasiko use or --cluster/-n)"),
+    ], ("Variable", "Description"))
+
+    _section("Cloud credentials")
+    _cmd_table([
+        ("AWS_ACCESS_KEY_ID",          "AWS access key"),
+        ("AWS_SECRET_ACCESS_KEY",      "AWS secret key"),
+        ("AWS_DEFAULT_REGION",         "AWS default region"),
+        ("DIGITALOCEAN_ACCESS_TOKEN",  "DigitalOcean API token"),
+    ], ("Variable", "Description"))
+
+    _section("Cluster setup")
+    _cmd_table([
+        ("NASIKO_PROVIDER",                  "aws or digitalocean"),
+        ("NASIKO_REGION",                    "Cloud region (e.g. us-east-1, nyc3)"),
+        ("KUBECONFIG",                       "Path to kubeconfig file"),
+        ("NASIKO_CLUSTER_NAME",              "Cluster name"),
+        ("NASIKO_TERRAFORM_DIR",             "Terraform modules directory"),
+        ("NASIKO_STATE_DIR",                 "Terraform state directory"),
+        ("NASIKO_TF_BACKEND",                "local, s3, gcs, or remote"),
+    ], ("Variable", "Description"))
+
+    _section("Registry & apps")
+    _cmd_table([
+        ("NASIKO_CONTAINER_REGISTRY_TYPE",  "harbor or cloud"),
+        ("NASIKO_REGISTRY_USER",            "Registry username"),
+        ("NASIKO_REGISTRY_PASS",            "Registry password"),
+        ("NASIKO_DOMAIN",                   "Domain for Harbor"),
+        ("NASIKO_EMAIL",                    "Email for SSL certificates"),
+        ("NASIKO_SUPERUSER_USERNAME",       "Superuser username (default: admin)"),
+        ("NASIKO_SUPERUSER_EMAIL",          "Superuser email"),
+        ("OPENAI_API_KEY",                  "OpenAI key for LLM query routing"),
+        ("NASIKO_PUBLIC_REGISTRY_USER",     "Docker Hub namespace for public images"),
+    ], ("Variable", "Description"))
+
+    _section("GitHub OAuth")
+    _cmd_table([
+        ("GITHUB_CLIENT_ID",     "GitHub OAuth App client ID"),
+        ("GITHUB_CLIENT_SECRET", "GitHub OAuth App client secret"),
+    ], ("Variable", "Description"))
+
+    _section("Port overrides (local stack)")
+    _cmd_table([
+        ("NASIKO_PORT_KONG",             "9100 — Kong Gateway (main entry)"),
+        ("NASIKO_PORT_KONG_ADMIN",       "9101 — Kong Admin API"),
+        ("NASIKO_PORT_BACKEND",          "8000 — Backend API"),
+        ("NASIKO_PORT_AUTH",             "8082 — Auth Service"),
+        ("NASIKO_PORT_ROUTER",           "8081 — Query Router"),
+        ("NASIKO_PORT_CHAT",             "8083 — Chat History"),
+        ("NASIKO_PORT_WEB",              "4000 — Web UI"),
+        ("NASIKO_PORT_KONGA",            "1337 — Konga"),
+        ("NASIKO_PORT_SERVICE_REGISTRY", "8080 — Agent Discovery"),
+        ("NASIKO_PORT_MONGODB",          "27017 — MongoDB"),
+        ("NASIKO_PORT_REDIS",            "6379 — Redis"),
+        ("NASIKO_PORT_LANGTRACE",        "3000 — Langtrace UI"),
+        ("NASIKO_PORT_OTEL_GRPC",        "4317 — OpenTelemetry gRPC"),
+        ("NASIKO_PORT_OTEL_HTTP",        "4318 — OpenTelemetry HTTP"),
+    ], ("Variable", "Default — Service"))
+
+
+# ─────────────────────────────────────────────────────────
+# DISPATCH
+# ─────────────────────────────────────────────────────────
+
+TOPICS = {
+    "install":       show_install,
+    "quickstart":    show_quickstart,
+    "concepts":      show_concepts,
+    "auth":          show_auth,
+    "cluster":       show_cluster,
+    "github":        show_github,
+    "agent":         show_agent,
+    "chat":          show_chat,
+    "observability": show_observability,
+    "access":        show_access,
+    "local":         show_local,
+    "n8n":           show_n8n,
+    "images":        show_images,
+    "user":          show_user,
+    "search":        show_search,
+    "env":           show_env,
+}
+
+
+def show_docs(topic: str = None):
+    if not topic:
+        show_overview()
+        return
+
+    fn = TOPICS.get(topic.lower())
+    if fn:
+        fn()
+    else:
+        console.print(f"[red]Unknown topic:[/red] '{topic}'\n")
+        console.print("Available topics: " + ", ".join(f"[cyan]{t}[/cyan]" for t in TOPICS))
+        console.print("\nRun [cyan]nasiko docs[/cyan] for an overview.")

--- a/cli/commands/github.py
+++ b/cli/commands/github.py
@@ -36,21 +36,50 @@ def get_github_status():
         raise typer.Exit(1)
 
 
+def _print_github_oauth_setup_instructions(api_url: str):
+    """Print clear instructions for configuring GitHub OAuth."""
+    console.print("\n[bold yellow]GitHub OAuth is not configured on this cluster.[/bold yellow]")
+    console.print("\nTo enable it, follow these steps:\n")
+    console.print("[bold]1. Create a GitHub OAuth App[/bold]")
+    console.print("   Go to: [cyan]https://github.com/settings/developers[/cyan]")
+    console.print("   → OAuth Apps → New OAuth App")
+    console.print(f"   → Homepage URL:      [cyan]{api_url}[/cyan]")
+    console.print(f"   → Callback URL:      [cyan]{api_url}/auth/github/callback[/cyan]")
+    console.print("\n[bold]2. Add credentials to your env file[/bold]")
+    console.print("   Add these lines to [cyan].nasiko-local.env[/cyan] (or your cluster's env file):")
+    console.print("   [dim]GITHUB_CLIENT_ID=your_client_id[/dim]")
+    console.print("   [dim]GITHUB_CLIENT_SECRET=your_client_secret[/dim]")
+    console.print("\n[bold]3. Restart the stack to apply[/bold]")
+    console.print("   [cyan]nasiko local down && nasiko local up[/cyan]")
+    console.print("\nThen run [bold]nasiko github connect[/bold] again.\n")
+
+
 def login_command():
     """
     Authenticate with GitHub via the Nasiko backend automatically.
     """
-    console.print("[bold magenta]--- GitHub Authentication ---[/bold magenta]")
-    console.print("A browser window will open for you to authorize the application.")
-
     try:
         client = get_api_client()
 
-        # The login endpoint now handles authentication automatically and returns a redirect
+        # Check if already connected on this cluster (no auth required)
+        status_response = client.get(APIEndpoints.GITHUB_TOKEN, require_auth=False)
+        if status_response.status_code == 200:
+            status = status_response.json()
+            if status.get("success") and status.get("status") == "connected":
+                console.print(f"[green]GitHub already connected[/] as [bold]{status.get('username')}[/bold] on this cluster.")
+                return
+
+        console.print("[bold magenta]--- GitHub Authentication ---[/bold magenta]")
+        console.print("A browser window will open for you to authorize the application.")
         console.print("\n[cyan]Initiating GitHub login...[/cyan]")
 
-        # Call the login endpoint which will return an auth URL
-        response = client.get(APIEndpoints.GITHUB_LOGIN)
+        response = client.get(APIEndpoints.GITHUB_LOGIN, require_auth=False)
+
+        # Preflight: detect unconfigured GitHub OAuth
+        if response.status_code == 404:
+            _print_github_oauth_setup_instructions(client.base_url)
+            raise typer.Exit(1)
+
         result = client.handle_response(response)
         if result is None:
             raise typer.Exit(1)
@@ -73,12 +102,10 @@ def login_command():
             )
             console.print(f"[cyan]{auth_url}[/cyan]")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"[red]Error: could not initiate GitHub login: {e}[/red]")
-        console.print(
-            "[yellow]You can try accessing the login URL manually in your browser:[/yellow]"
-        )
-        console.print(f"[cyan]{APIEndpoints.GITHUB_LOGIN}[/cyan]")
         raise typer.Exit(1)
 
     # Wait a moment for the browser to hit the login endpoint and initialize the session
@@ -97,8 +124,8 @@ def login_command():
 
     while time.time() - start_time < timeout_seconds:
         try:
-            # Check if token is available
-            response = client.get(APIEndpoints.GITHUB_TOKEN)
+            # Check if token is available (no auth required — this IS the auth flow)
+            response = client.get(APIEndpoints.GITHUB_TOKEN, require_auth=False)
 
             # If we get a successful response, check if we have a valid token
             if response.status_code == 200:

--- a/cli/commands/observability.py
+++ b/cli/commands/observability.py
@@ -13,7 +13,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.box import ROUNDED
 from datetime import datetime, timedelta
 from core.settings import APIEndpoints
-from auth.auth_manager import AuthManager
+from core.api_client import get_api_client
 
 console = Console()
 
@@ -97,18 +97,6 @@ def get_status_color(status):
     return status_colors.get(str(status).lower(), "white")
 
 
-def get_auth_headers():
-    """Get authentication headers"""
-    auth_manager = AuthManager()
-    headers = auth_manager.get_auth_headers()
-    if not headers:
-        console.print(
-            "[red]Error: Not authenticated. Please run 'nasiko auth login' first.[/red]"
-        )
-        raise typer.Exit(1)
-    return headers
-
-
 def sessions_command(
     agent_id: Optional[str] = typer.Argument(
         None, help="Agent ID to filter sessions (optional)"
@@ -126,7 +114,7 @@ def sessions_command(
     """Get observability sessions for agents"""
 
     try:
-        headers = get_auth_headers()
+        client = get_api_client()
 
         # Calculate start time for filtering
         start_time = (datetime.utcnow() - timedelta(days=days)).isoformat() + "Z"
@@ -139,12 +127,7 @@ def sessions_command(
             console=console,
         ) as progress:
             task = progress.add_task("Fetching observability sessions...", total=None)
-            response = requests.get(
-                APIEndpoints.OBSERVABILITY_SESSIONS,
-                headers=headers,
-                params=params,
-                timeout=30,
-            )
+            response = client.get(APIEndpoints.OBSERVABILITY_SESSIONS, params=params)
             progress.remove_task(task)
 
         if response.status_code == 401:
@@ -225,9 +208,9 @@ def session_details_command(
     """Get detailed information about a specific session"""
 
     try:
-        headers = get_auth_headers()
+        client = get_api_client()
 
-        url = APIEndpoints.OBSERVABILITY_SESSION_DETAILS.format(session_id=session_id)
+        endpoint = APIEndpoints.OBSERVABILITY_SESSION_DETAILS.format(session_id=session_id)
 
         with Progress(
             SpinnerColumn(),
@@ -237,7 +220,7 @@ def session_details_command(
             task = progress.add_task(
                 f"Fetching session {session_id[:8]}...", total=None
             )
-            response = requests.get(url, headers=headers, timeout=30)
+            response = client.get(endpoint)
             progress.remove_task(task)
 
         if response.status_code == 404:
@@ -286,9 +269,9 @@ def trace_details_command(
     """Get detailed trace information with nested spans"""
 
     try:
-        headers = get_auth_headers()
+        client = get_api_client()
 
-        url = APIEndpoints.OBSERVABILITY_TRACE_DETAILS.format(
+        endpoint = APIEndpoints.OBSERVABILITY_TRACE_DETAILS.format(
             project_id=project_id, trace_id=trace_id
         )
 
@@ -298,7 +281,7 @@ def trace_details_command(
             console=console,
         ) as progress:
             task = progress.add_task(f"Fetching trace {trace_id[:8]}...", total=None)
-            response = requests.get(url, headers=headers, timeout=30)
+            response = client.get(endpoint)
             progress.remove_task(task)
 
         if response.status_code == 404:
@@ -348,9 +331,9 @@ def span_details_command(
     """Get detailed information about a specific span"""
 
     try:
-        headers = get_auth_headers()
+        client = get_api_client()
 
-        url = APIEndpoints.OBSERVABILITY_SPAN_DETAILS.format(span_id=span_id)
+        endpoint = APIEndpoints.OBSERVABILITY_SPAN_DETAILS.format(span_id=span_id)
 
         with Progress(
             SpinnerColumn(),
@@ -358,7 +341,7 @@ def span_details_command(
             console=console,
         ) as progress:
             task = progress.add_task(f"Fetching span {span_id[:8]}...", total=None)
-            response = requests.get(url, headers=headers, timeout=30)
+            response = client.get(endpoint)
             progress.remove_task(task)
 
         if response.status_code == 404:
@@ -407,11 +390,11 @@ def agent_stats_command(
     """Get performance statistics for an agent"""
 
     try:
-        headers = get_auth_headers()
+        client = get_api_client()
 
         start_time = (datetime.utcnow() - timedelta(days=days)).isoformat() + "Z"
 
-        url = APIEndpoints.OBSERVABILITY_AGENT_STATS.format(agent_id=agent_id)
+        endpoint = APIEndpoints.OBSERVABILITY_AGENT_STATS.format(agent_id=agent_id)
         params = {"start_time": start_time}
 
         with Progress(
@@ -420,7 +403,7 @@ def agent_stats_command(
             console=console,
         ) as progress:
             task = progress.add_task(f"Fetching stats for {agent_id}...", total=None)
-            response = requests.get(url, headers=headers, params=params, timeout=30)
+            response = client.get(endpoint, params=params)
             progress.remove_task(task)
 
         if response.status_code == 404:

--- a/cli/commands/observability.py
+++ b/cli/commands/observability.py
@@ -103,7 +103,7 @@ def get_auth_headers():
     headers = auth_manager.get_auth_headers()
     if not headers:
         console.print(
-            "[red]Error: Not authenticated. Please run 'nasiko login' first.[/red]"
+            "[red]Error: Not authenticated. Please run 'nasiko auth login' first.[/red]"
         )
         raise typer.Exit(1)
     return headers

--- a/cli/core/api_client.py
+++ b/cli/core/api_client.py
@@ -109,12 +109,12 @@ class APIClient:
         """Ensure user is authenticated"""
         if not self.auth_manager.is_logged_in():
             typer.echo("❌ Please login first:")
-            typer.echo("   nasiko login")
+            typer.echo("   nasiko auth login")
             raise typer.Exit(1)
 
         if not self.auth_manager.refresh_token_if_needed():
             typer.echo("❌ Authentication failed. Please login again:")
-            typer.echo("   nasiko login")
+            typer.echo("   nasiko auth login")
             raise typer.Exit(1)
 
     def _make_request(
@@ -147,7 +147,7 @@ class APIClient:
             # Handle auth failures
             if response.status_code == 401 and require_auth:
                 typer.echo("❌ Authentication failed. Please login again:")
-                typer.echo("   nasiko login")
+                typer.echo("   nasiko auth login")
                 self.auth_manager.logout()
                 raise typer.Exit(1)
 
@@ -242,7 +242,7 @@ class APIClient:
 
                 if response.status_code == 401 and require_auth:
                     typer.echo("❌ Authentication failed. Please login again:")
-                    typer.echo("   nasiko login")
+                    typer.echo("   nasiko auth login")
                     self.auth_manager.logout()
                     raise typer.Exit(1)
 

--- a/cli/core/api_client.py
+++ b/cli/core/api_client.py
@@ -93,17 +93,9 @@ class APIClient:
         if endpoint.startswith("http"):
             return endpoint
 
-        # All APIEndpoints are relative paths like "/registry"
-        # We assume they belong under /api/v1 unless they explicitly start with /auth
-
+        # All APIEndpoints are relative paths — always route through /api/v1/
         endpoint = endpoint.lstrip("/")
-
-        if endpoint.startswith("auth/"):
-            # Auth service routes (e.g. /auth/users/...) are usually under root
-            return f"{self.base_url}/{endpoint}"
-        else:
-            # Standard API routes
-            return f"{self.api_url}/{endpoint}"
+        return f"{self.api_url}/{endpoint}"
 
     def _require_auth(self):
         """Ensure user is authenticated"""

--- a/cli/core/context.py
+++ b/cli/core/context.py
@@ -1,0 +1,55 @@
+"""
+Context storage for Nasiko CLI.
+
+Persists the active cluster name to ~/.nasiko/context.json so commands
+operate on the right cluster without requiring --cluster/-n every time.
+"""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from setup.config import get_nasiko_home
+
+
+def _context_path() -> Path:
+    """Returns ~/.nasiko/context.json, creating the parent dir if needed."""
+    return get_nasiko_home() / "context.json"
+
+
+def read_context() -> dict:
+    """
+    Load context.json. Returns an empty dict if the file is missing or malformed.
+    Never raises.
+    """
+    path = _context_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def write_context(data: dict) -> None:
+    """
+    Overwrite context.json with the supplied dict.
+    File is created with 0o600 permissions (owner read/write only).
+    """
+    path = _context_path()
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+    path.chmod(0o600)
+
+
+def get_active_cluster() -> Optional[str]:
+    """Return the active cluster name from context.json, or None."""
+    return read_context().get("active_cluster")
+
+
+def set_active_cluster(name: str) -> None:
+    """Set (or update) the active_cluster key in context.json."""
+    ctx = read_context()
+    ctx["active_cluster"] = name
+    write_context(ctx)

--- a/cli/groups/agent_group.py
+++ b/cli/groups/agent_group.py
@@ -8,8 +8,54 @@ import typer
 # Create Agent command group
 agent_app = typer.Typer(help="Agent management and registry operations")
 
+# N8N sub-group under agent
+from groups.n8n_group import n8n_app
+agent_app.add_typer(n8n_app, name="n8n", help="N8N workflow integration")
 
-@agent_app.command(name="upload-zip")
+
+@agent_app.command(name="deploy")
+def deploy(
+    source: str = typer.Argument(
+        ".",
+        help="Source to deploy: directory path, .zip file, or GitHub repo (owner/repo)",
+    ),
+    agent_name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Agent name (auto-detected if not provided)",
+    ),
+):
+    """Deploy an agent from a directory, zip file, or GitHub repo.
+
+    Examples:
+      nasiko agent deploy .
+      nasiko agent deploy ./my-agent.zip
+      nasiko agent deploy owner/repo
+    """
+    from pathlib import Path
+    from commands.upload_agent import upload_zip_command, upload_directory_command
+
+    path = Path(source)
+
+    if path.exists():
+        if path.is_dir():
+            upload_directory_command(str(path), agent_name)
+        elif path.is_file() and path.suffix.lower() == ".zip":
+            upload_zip_command(str(path), agent_name)
+        else:
+            typer.echo(f"Error: '{source}' is not a directory or .zip file.")
+            raise typer.Exit(1)
+    elif "/" in source and not source.startswith("/"):
+        # Looks like owner/repo — delegate to github clone
+        from commands.github import clone_command
+        clone_command(repo=source, branch=None)
+    else:
+        typer.echo(f"Error: '{source}' not found and doesn't look like a GitHub repo (owner/repo).")
+        raise typer.Exit(1)
+
+
+@agent_app.command(name="upload-zip", hidden=True)
 def upload_zip(
     zip_file: str = typer.Argument(
         ..., help="Path to the .zip file containing the agent"
@@ -21,13 +67,13 @@ def upload_zip(
         help="Optional agent name (will be auto-detected if not provided)",
     ),
 ):
-    """Upload and deploy an agent from a .zip file."""
+    """[Deprecated] Use 'agent deploy' instead."""
     from commands.upload_agent import upload_zip_command
 
     upload_zip_command(zip_file, agent_name)
 
 
-@agent_app.command(name="upload-directory")
+@agent_app.command(name="upload-directory", hidden=True)
 def upload_directory(
     directory_path: str = typer.Argument(
         ..., help="Path to the directory containing the agent"
@@ -39,7 +85,7 @@ def upload_directory(
         help="Optional agent name (will be auto-detected if not provided)",
     ),
 ):
-    """Upload and deploy an agent from a local directory."""
+    """[Deprecated] Use 'agent deploy' instead."""
     from commands.upload_agent import upload_directory_command
 
     upload_directory_command(directory_path, agent_name)

--- a/cli/groups/chat_group.py
+++ b/cli/groups/chat_group.py
@@ -9,19 +9,17 @@ import typer
 chat_app = typer.Typer(help="Chat sessions and conversation history")
 
 
-@chat_app.command(name="create-session")
-def chat_session_create(
-    agent_name: Optional[str] = typer.Option(
-        None, "--agent", "-a", help="Agent name to associate with session"
-    ),
+@chat_app.command(name="start")
+def chat_start(
+    agent_name: str = typer.Argument(..., help="Agent name to chat with"),
 ):
-    """Create a new chat session."""
-    from commands.chat_history import create_session
+    """Start an interactive chat session with an agent."""
+    from commands.chat_history import interactive_chat
 
-    create_session(agent_name)
+    interactive_chat(agent_name)
 
 
-@chat_app.command(name="list-sessions")
+@chat_app.command(name="sessions")
 def chat_sessions(
     limit: int = typer.Option(
         10, "--limit", "-l", help="Number of sessions per page (1-20)"
@@ -58,8 +56,8 @@ def chat_history(
     get_chat_history(session_id, limit, cursor, direction)
 
 
-@chat_app.command(name="delete-session")
-def chat_session_delete(
+@chat_app.command(name="drop")
+def chat_drop(
     session_id: str = typer.Argument(..., help="Session ID to delete"),
 ):
     """Delete a chat session."""
@@ -88,3 +86,38 @@ def chat_send(
     from commands.chat_send import send_message_command
 
     send_message_command(url, message, session_id)
+
+
+# Backward compat aliases (hidden)
+@chat_app.command(name="create-session", hidden=True)
+def chat_session_create(
+    agent_name: Optional[str] = typer.Option(
+        None, "--agent", "-a", help="Agent name to associate with session"
+    ),
+):
+    """[Deprecated] Use 'chat start <agent>' instead."""
+    from commands.chat_history import create_session
+
+    create_session(agent_name)
+
+
+@chat_app.command(name="list-sessions", hidden=True)
+def chat_list_sessions(
+    limit: int = typer.Option(10, "--limit", "-l"),
+    cursor: Optional[str] = typer.Option(None, "--cursor"),
+    direction: str = typer.Option("after", "--direction"),
+):
+    """[Deprecated] Use 'chat sessions' instead."""
+    from commands.chat_history import list_sessions
+
+    list_sessions(limit, cursor, direction)
+
+
+@chat_app.command(name="delete-session", hidden=True)
+def chat_session_delete(
+    session_id: str = typer.Argument(..., help="Session ID to delete"),
+):
+    """[Deprecated] Use 'chat drop' instead."""
+    from commands.chat_history import delete_session
+
+    delete_session(session_id)

--- a/cli/groups/cluster_group.py
+++ b/cli/groups/cluster_group.py
@@ -187,6 +187,45 @@ def destroy(
     )
 
 
+@cluster_app.command("remove")
+def remove_cluster(
+    name: str = typer.Argument(..., help="Name of the cluster to remove from the list"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+):
+    """Remove a cluster entry from the local list (does not destroy cloud resources)."""
+    import shutil
+    from rich.console import Console
+    from setup.config import get_nasiko_home
+    from core.context import get_active_cluster, set_active_cluster
+
+    console = Console()
+    state_root = get_nasiko_home() / "state"
+
+    found = []
+    for provider_dir in state_root.iterdir():
+        if not provider_dir.is_dir():
+            continue
+        cluster_dir = provider_dir / name
+        if cluster_dir.is_dir():
+            found.append(cluster_dir)
+
+    if not found:
+        console.print(f"[red]Cluster '[bold]{name}[/bold]' not found.[/red]")
+        raise typer.Exit(1)
+
+    if not yes:
+        typer.confirm(f"Remove cluster '{name}' from the list?", abort=True)
+
+    for cluster_dir in found:
+        shutil.rmtree(cluster_dir)
+
+    if get_active_cluster() == name:
+        set_active_cluster(None)
+        console.print(f"[yellow]Active cluster unset (was '{name}').[/yellow]")
+
+    console.print(f"[green]Cluster '[bold]{name}[/bold]' removed.[/green]")
+
+
 @cluster_app.command("list")
 def list_clusters():
     """List all clusters managed by Nasiko."""

--- a/cli/groups/cluster_group.py
+++ b/cli/groups/cluster_group.py
@@ -42,6 +42,17 @@ def connect(
         console.print("[red]URL must start with http:// or https://[/]")
         raise typer.Exit(1)
 
+    # Warn if URL contains a path — the gateway URL should be the root
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    if parsed.path.rstrip("/") not in ("", "/"):
+        root_url = f"{parsed.scheme}://{parsed.netloc}"
+        console.print(f"[yellow]Warning: URL contains a path '{parsed.path}' — the API gateway URL should be the root.[/]")
+        console.print(f"[yellow]Did you mean: {root_url}[/]")
+        if not typer.confirm("Continue anyway?", default=False):
+            console.print(f"[dim]Hint: nasiko cluster connect {name} --url {root_url}[/]")
+            raise typer.Exit(0)
+
     if auth not in ("key", "github", "digitalocean"):
         console.print("[red]--auth must be one of: key, github, digitalocean[/]")
         raise typer.Exit(1)

--- a/cli/groups/cluster_group.py
+++ b/cli/groups/cluster_group.py
@@ -1,0 +1,355 @@
+"""
+Cluster command group.
+
+Maps new `nasiko cluster *` surface to existing setup module implementations.
+"""
+
+from typing import Optional
+import typer
+
+cluster_app = typer.Typer(help="Cluster lifecycle — create, inspect, and destroy clusters")
+create_app = typer.Typer(help="Create a new cluster", no_args_is_help=True)
+setup_app = typer.Typer(help="Deploy cluster components", no_args_is_help=True)
+registry_app = typer.Typer(help="Setup container registry", no_args_is_help=True)
+
+cluster_app.add_typer(create_app, name="create")
+cluster_app.add_typer(setup_app, name="setup")
+setup_app.add_typer(registry_app, name="registry")
+
+
+# ---------------------------------------------------------------------------
+# nasiko cluster create
+# ---------------------------------------------------------------------------
+
+@create_app.command("local")
+def create_local(
+    name: str = typer.Option("local", "--name", "-n", help="Name for the cluster"),
+):
+    """Create a local Docker Compose cluster."""
+    typer.echo("⚠️  Local Docker Compose cluster creation is not yet implemented.")
+    typer.echo("Coming in a future release.")
+    raise typer.Exit(1)
+
+
+@create_app.command("local-k8s")
+def create_local_k8s(
+    name: str = typer.Option("local-k8s", "--name", "-n", help="Name for the cluster"),
+):
+    """Create a local Kubernetes cluster via kind/minikube."""
+    typer.echo("⚠️  Local Kubernetes cluster creation is not yet implemented.")
+    typer.echo("Coming in a future release.")
+    raise typer.Exit(1)
+
+
+@create_app.command("remote")
+def create_remote(
+    provider: str = typer.Option(
+        ..., "--provider", help="Cloud provider: aws or digitalocean"
+    ),
+    name: str = typer.Option(
+        "nasiko", "--name", "-n", help="Name for the Kubernetes cluster"
+    ),
+    region: str = typer.Option(None, help="Cloud region (e.g. us-east-1, nyc3)"),
+    node_size: str = typer.Option(None, help="Node instance type"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Auto-approve Terraform apply"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose Terraform output"),
+    terraform_dir: str = typer.Option(
+        None, "--terraform-dir", "-t", envvar="NASIKO_TERRAFORM_DIR",
+        help="Path to Terraform modules directory"
+    ),
+    state_dir: str = typer.Option(
+        None, "--state-dir", envvar="NASIKO_STATE_DIR",
+        help="Path for storing Terraform state"
+    ),
+):
+    """Provision a remote Kubernetes cluster via Terraform (AWS or DigitalOcean)."""
+    from setup.k8s_setup import create, Provider
+    create(
+        provider=Provider(provider),
+        cluster_name=name,
+        region=region,
+        node_size=node_size,
+        auto_approve=yes,
+        verbose=verbose,
+        terraform_dir=terraform_dir,
+        state_dir=state_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# nasiko cluster destroy / list / output / state-info / init-modules
+# ---------------------------------------------------------------------------
+
+@cluster_app.command("destroy")
+def destroy(
+    name: str = typer.Argument(..., help="Name of the cluster to destroy"),
+    provider: str = typer.Option(
+        ..., "--provider", help="Cloud provider: aws or digitalocean"
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Auto-approve Terraform destroy"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose Terraform output"),
+    cleanup: bool = typer.Option(False, "--cleanup", help="Remove local state after destroy"),
+    terraform_dir: str = typer.Option(
+        None, "--terraform-dir", "-t", envvar="NASIKO_TERRAFORM_DIR"
+    ),
+    state_dir: str = typer.Option(
+        None, "--state-dir", "-s", envvar="NASIKO_STATE_DIR"
+    ),
+):
+    """Tear down a cluster and all related resources."""
+    from setup.k8s_setup import destroy as _destroy, Provider
+    _destroy(
+        provider=Provider(provider),
+        cluster_name=name,
+        auto_approve=yes,
+        verbose=verbose,
+        terraform_dir=terraform_dir,
+        state_dir=state_dir,
+        cleanup_state=cleanup,
+    )
+
+
+@cluster_app.command("list")
+def list_clusters(
+    state_dir: str = typer.Option(
+        None, "--state-dir", "-s", envvar="NASIKO_STATE_DIR",
+        help="Path for storing Terraform state"
+    ),
+):
+    """List all clusters managed by Nasiko."""
+    from setup.k8s_setup import list_clusters as _list
+    _list(state_dir=state_dir)
+
+
+@cluster_app.command("output")
+def output(
+    provider: str = typer.Option(..., "--provider", help="Cloud provider: aws or digitalocean"),
+    name: str = typer.Option("nasiko", "--name", "-n", help="Cluster name"),
+    terraform_dir: str = typer.Option(
+        None, "--terraform-dir", "-t", envvar="NASIKO_TERRAFORM_DIR"
+    ),
+    state_dir: str = typer.Option(
+        None, "--state-dir", "-s", envvar="NASIKO_STATE_DIR"
+    ),
+):
+    """Show Terraform outputs for an existing cluster."""
+    from setup.k8s_setup import output as _output, Provider
+    _output(
+        provider=Provider(provider),
+        cluster_name=name,
+        terraform_dir=terraform_dir,
+        state_dir=state_dir,
+    )
+
+
+@cluster_app.command("state-info")
+def state_info(
+    provider: str = typer.Option(..., "--provider", help="Cloud provider: aws or digitalocean"),
+    name: str = typer.Option("nasiko", "--name", "-n", help="Cluster name"),
+    state_dir: str = typer.Option(
+        None, "--state-dir", "-s", envvar="NASIKO_STATE_DIR"
+    ),
+):
+    """Show detailed Terraform state info for a cluster."""
+    from setup.k8s_setup import state_info as _state_info, Provider
+    _state_info(
+        provider=Provider(provider),
+        cluster_name=name,
+        state_dir=state_dir,
+    )
+
+
+@cluster_app.command("init-modules")
+def init_modules(
+    source: str = typer.Option(None, "--source", "-s", help="Source directory for Terraform modules"),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing modules"),
+):
+    """Copy Terraform modules to ~/.nasiko/terraform/."""
+    from setup.k8s_setup import init_modules as _init_modules
+    _init_modules(source=source, force=force)
+
+
+# ---------------------------------------------------------------------------
+# nasiko cluster bootstrap / configure-github-oauth / cleanup /
+#             init-superuser / get-superuser
+# ---------------------------------------------------------------------------
+
+@cluster_app.command("bootstrap")
+def bootstrap(
+    config: str = typer.Option(None, "--config", "-c", help="Path to .env config file"),
+    kubeconfig: str = typer.Option(None, envvar="KUBECONFIG", help="Existing kubeconfig (skips provisioning)"),
+    provider: str = typer.Option(None, envvar="NASIKO_PROVIDER", help="Cloud provider: aws or digitalocean"),
+    cluster_name: str = typer.Option("nasiko-cluster", envvar="NASIKO_CLUSTER_NAME", help="Cluster name"),
+    region: str = typer.Option(None, envvar="NASIKO_REGION", help="Cloud region"),
+    terraform_dir: str = typer.Option(None, "--terraform-dir", "-t", envvar="NASIKO_TERRAFORM_DIR"),
+    state_dir: str = typer.Option(None, "--state-dir", envvar="NASIKO_STATE_DIR"),
+    registry_type: str = typer.Option("harbor", envvar="NASIKO_CONTAINER_REGISTRY_TYPE", help="harbor or cloud"),
+    domain: str = typer.Option(None, envvar="NASIKO_DOMAIN"),
+    email: str = typer.Option(None, envvar="NASIKO_EMAIL"),
+    registry_user: str = typer.Option("admin", envvar="NASIKO_REGISTRY_USER"),
+    registry_pass: str = typer.Option(None, envvar="NASIKO_REGISTRY_PASS"),
+    cloud_reg_name: str = typer.Option("nasiko-images", envvar="NASIKO_CONTAINER_REGISTRY_NAME"),
+    openai_key: str = typer.Option(None, envvar="OPENAI_API_KEY"),
+    public_registry_user: str = typer.Option("karannasiko", envvar="NASIKO_PUBLIC_REGISTRY_USER"),
+    superuser_username: str = typer.Option("admin", envvar="NASIKO_SUPERUSER_USERNAME"),
+    superuser_email: str = typer.Option("admin@nasiko.com", envvar="NASIKO_SUPERUSER_EMAIL"),
+    clean_existing: bool = typer.Option(True, "--clean-existing/--no-clean-existing"),
+):
+    """Provision cluster + registry + buildkit + core apps in one shot."""
+    from setup.setup import bootstrap as _bootstrap, RegistryType
+    from setup.k8s_setup import Provider
+    _bootstrap(
+        config=config,
+        kubeconfig=kubeconfig,
+        provider=Provider(provider) if provider else None,
+        cluster_name=cluster_name,
+        region=region,
+        terraform_dir=terraform_dir,
+        state_dir=state_dir,
+        registry_type=RegistryType(registry_type),
+        domain=domain,
+        email=email,
+        registry_user=registry_user,
+        registry_pass=registry_pass,
+        cloud_reg_name=cloud_reg_name,
+        openai_key=openai_key,
+        public_registry_user=public_registry_user,
+        superuser_username=superuser_username,
+        superuser_email=superuser_email,
+        clean_existing=clean_existing,
+    )
+
+
+@cluster_app.command("configure-github-oauth")
+def configure_github_oauth(
+    config: str = typer.Option(None, "--config", "-c"),
+    kubeconfig: str = typer.Option(None, envvar="KUBECONFIG"),
+    namespace: str = typer.Option("nasiko"),
+    deployment: str = typer.Option("nasiko-backend"),
+    container: str = typer.Option(None),
+    restart: bool = typer.Option(True, "--restart/--no-restart"),
+):
+    """Patch GitHub OAuth env vars without re-bootstrapping."""
+    from setup.setup import configure_github_oauth as _fn
+    _fn(
+        config=config,
+        kubeconfig=kubeconfig,
+        namespace=namespace,
+        deployment=deployment,
+        container=container,
+        restart=restart,
+    )
+
+
+@cluster_app.command("cleanup")
+def cleanup(
+    kubeconfig: str = typer.Option(..., envvar="KUBECONFIG", help="Kubeconfig for the cluster to clean"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Auto-approve cleanup"),
+):
+    """Remove all Nasiko resources from a cluster (namespaces, Helm releases)."""
+    from setup.setup import cleanup as _cleanup
+    _cleanup(kubeconfig=kubeconfig, auto_approve=yes)
+
+
+@cluster_app.command("init-superuser")
+def init_superuser(
+    kubeconfig: str = typer.Option(None, envvar="KUBECONFIG"),
+    superuser_username: str = typer.Option("admin", envvar="NASIKO_SUPERUSER_USERNAME"),
+    superuser_email: str = typer.Option("admin@nasiko.com", envvar="NASIKO_SUPERUSER_EMAIL"),
+    provider: str = typer.Option(None, envvar="NASIKO_PROVIDER"),
+):
+    """Create/recreate the super user and retrieve credentials."""
+    from setup.setup import init_superuser as _fn
+    from setup.k8s_setup import Provider
+    _fn(
+        kubeconfig=kubeconfig,
+        superuser_username=superuser_username,
+        superuser_email=superuser_email,
+        provider=Provider(provider) if provider else None,
+    )
+
+
+@cluster_app.command("get-superuser")
+def get_superuser(
+    kubeconfig: str = typer.Option(None, envvar="KUBECONFIG"),
+    provider: str = typer.Option(None, envvar="NASIKO_PROVIDER"),
+    save: bool = typer.Option(True, "--save/--no-save"),
+):
+    """Fetch existing super user credentials (read-only)."""
+    from setup.setup import get_superuser as _fn
+    from setup.k8s_setup import Provider
+    _fn(
+        kubeconfig=kubeconfig,
+        provider=Provider(provider) if provider else None,
+        save_to_file=save,
+    )
+
+
+# ---------------------------------------------------------------------------
+# nasiko cluster setup registry harbor / cloud
+# nasiko cluster setup buildkit
+# nasiko cluster setup core
+# ---------------------------------------------------------------------------
+
+@registry_app.command("harbor")
+def setup_registry_harbor(
+    domain: str = typer.Option(None, help="Domain for Harbor (e.g. reg.example.com)"),
+    email: str = typer.Option(None, help="Email for Let's Encrypt"),
+    password: str = typer.Option(..., help="Harbor admin password"),
+    username: str = typer.Option("admin", help="Harbor admin username"),
+):
+    """Deploy Harbor container registry via Helm."""
+    from setup.harbor_setup import deploy
+    deploy(domain=domain, email=email, password=password, username=username)
+
+
+@registry_app.command("cloud")
+def setup_registry_cloud(
+    provider: str = typer.Option(..., "--provider", help="aws or digitalocean"),
+    region: str = typer.Option(None, help="Region (required for AWS)"),
+    name: str = typer.Option(..., "--name", "-n", help="ECR repo or DO registry name"),
+):
+    """Setup ECR or DigitalOcean container registry."""
+    from setup.container_registry_setup import deploy
+    deploy(provider=provider, region=region, name=name)
+
+
+@setup_app.command("buildkit")
+def setup_buildkit(
+    registry: str = typer.Option(..., help="Registry URL"),
+    username: str = typer.Option(None, help="Registry username"),
+    password: str = typer.Option(None, help="Registry password"),
+    iam_role_arn: str = typer.Option(None, help="AWS IAM Role ARN for IRSA"),
+):
+    """Deploy rootless BuildKit to the cluster."""
+    from setup.buildkit_setup import deploy
+    deploy(registry=registry, username=username, password=password, iam_role_arn=iam_role_arn)
+
+
+@setup_app.command("core")
+def setup_core(
+    registry_url: str = typer.Option(..., help="Registry URL"),
+    registry_user: str = typer.Option(None),
+    registry_pass: str = typer.Option(None),
+    public_user: str = typer.Option("karannasiko", envvar="NASIKO_PUBLIC_REGISTRY_USER"),
+    openai_key: str = typer.Option(None, envvar="OPENAI_API_KEY"),
+    environment: str = typer.Option("default"),
+    superuser_username: str = typer.Option("admin", envvar="NASIKO_SUPERUSER_USERNAME"),
+    superuser_email: str = typer.Option("admin@nasiko.com", envvar="NASIKO_SUPERUSER_EMAIL"),
+    provider: str = typer.Option(None, envvar="NASIKO_PROVIDER"),
+    region: str = typer.Option(None, envvar="NASIKO_REGION"),
+):
+    """Deploy backend, web, router, auth + infra to the cluster."""
+    from setup.app_setup import deploy
+    deploy(
+        registry_url=registry_url,
+        registry_user=registry_user,
+        registry_pass=registry_pass,
+        public_user=public_user,
+        openai_key=openai_key,
+        environment=environment,
+        superuser_username=superuser_username,
+        superuser_email=superuser_email,
+        provider=provider,
+        region=region,
+    )

--- a/cli/groups/cluster_group.py
+++ b/cli/groups/cluster_group.py
@@ -18,6 +18,72 @@ setup_app.add_typer(registry_app, name="registry")
 
 
 # ---------------------------------------------------------------------------
+# nasiko cluster connect
+# ---------------------------------------------------------------------------
+
+@cluster_app.command("connect")
+def connect(
+    name: str = typer.Argument(..., help="Name to give this cluster"),
+    url: str = typer.Option(..., "--url", "-u", help="API gateway URL (e.g. https://api.my-cluster.example.com)"),
+    login: bool = typer.Option(True, "--login/--no-login", help="Prompt for login after connecting"),
+    auth: str = typer.Option("key", "--auth", "-a", help="Login method: key, github, digitalocean"),
+):
+    """Connect to an existing remote cluster by registering its API URL."""
+    import os
+    from rich.console import Console
+    from setup.config import save_cluster_info
+    from core.context import set_active_cluster
+    from auth.auth_manager import get_auth_manager
+
+    console = Console()
+
+    # Validate URL format
+    if not url.startswith(("http://", "https://")):
+        console.print("[red]URL must start with http:// or https://[/]")
+        raise typer.Exit(1)
+
+    if auth not in ("key", "github", "digitalocean"):
+        console.print("[red]--auth must be one of: key, github, digitalocean[/]")
+        raise typer.Exit(1)
+
+    # Save cluster info
+    save_cluster_info(
+        provider="existing",
+        cluster_name=name,
+        data={"gateway_url": url.rstrip("/"), "type": "remote"},
+    )
+    set_active_cluster(name)
+    # Propagate to env so subsequent auth calls use the right cluster
+    os.environ["NASIKO_CLUSTER_NAME"] = name
+
+    console.print(f"[green]Connected to cluster:[/] [bold]{name}[/]")
+    console.print(f"[bold]API URL:[/] {url.rstrip('/')}")
+
+    if not login:
+        return
+
+    console.print()
+
+    if auth == "key":
+        access_key = typer.prompt("Access key")
+        access_secret = typer.prompt("Access secret", hide_input=True)
+        auth_manager = get_auth_manager(cluster_name=name)
+        if auth_manager.login(access_key, access_secret):
+            console.print("[green]Login successful![/] You're ready to use Nasiko.")
+        else:
+            console.print("[yellow]Login failed.[/] Try [bold]nasiko auth login[/] to retry.")
+
+    elif auth == "github":
+        from commands.github import login_command
+        console.print("[cyan]Logging in via GitHub SSO...[/cyan]")
+        login_command()
+
+    elif auth == "digitalocean":
+        console.print("[cyan]DigitalOcean SSO is not yet supported.[/cyan]")
+        console.print("Use [bold]nasiko auth login[/bold] with your access key instead.")
+
+
+# ---------------------------------------------------------------------------
 # nasiko cluster create
 # ---------------------------------------------------------------------------
 
@@ -26,9 +92,21 @@ def create_local(
     name: str = typer.Option("local", "--name", "-n", help="Name for the cluster"),
 ):
     """Create a local Docker Compose cluster."""
-    typer.echo("⚠️  Local Docker Compose cluster creation is not yet implemented.")
-    typer.echo("Coming in a future release.")
-    raise typer.Exit(1)
+    from groups.local_group import _ensure_docker_running, _ensure_docker_compose, local_up
+    from setup.config import save_cluster_info
+    from core.context import set_active_cluster
+
+    _ensure_docker_running()
+    _ensure_docker_compose()
+    local_up()
+
+    save_cluster_info(
+        provider="local",
+        cluster_name=name,
+        data={"gateway_url": "http://localhost:9100", "type": "docker-compose"},
+    )
+    set_active_cluster(name)
+    typer.echo(f"Active cluster set to: {name}")
 
 
 @create_app.command("local-k8s")
@@ -110,15 +188,33 @@ def destroy(
 
 
 @cluster_app.command("list")
-def list_clusters(
-    state_dir: str = typer.Option(
-        None, "--state-dir", "-s", envvar="NASIKO_STATE_DIR",
-        help="Path for storing Terraform state"
-    ),
-):
+def list_clusters():
     """List all clusters managed by Nasiko."""
-    from setup.k8s_setup import list_clusters as _list
-    _list(state_dir=state_dir)
+    from rich.console import Console
+    from rich.table import Table
+    from setup.config import list_clusters as _list_config
+    from core.context import get_active_cluster
+
+    console = Console()
+    clusters = _list_config()
+    active = get_active_cluster()
+
+    if not clusters:
+        console.print("[yellow]No clusters found.[/yellow]")
+        console.print("Create one with: [cyan]nasiko init[/cyan] or [cyan]nasiko cluster connect <name> --url <url>[/cyan]")
+        return
+
+    table = Table(title="Clusters")
+    table.add_column("Name", style="bold")
+    table.add_column("Provider")
+    table.add_column("URL")
+    table.add_column("Active")
+
+    for c in clusters:
+        is_active = "✓" if c.get("name") == active else ""
+        table.add_row(c.get("name", ""), c.get("provider", ""), c.get("url", ""), f"[green]{is_active}[/green]")
+
+    console.print(table)
 
 
 @cluster_app.command("output")

--- a/cli/groups/github_group.py
+++ b/cli/groups/github_group.py
@@ -9,16 +9,16 @@ import typer
 github_app = typer.Typer(help="GitHub integration and repository management")
 
 
-@github_app.command(name="login")
-def github_login():
+@github_app.command(name="connect")
+def github_connect():
     """Authenticate with GitHub via the Nasiko backend automatically."""
     from commands.github import login_command
 
     login_command()
 
 
-@github_app.command(name="logout")
-def github_logout():
+@github_app.command(name="disconnect")
+def github_disconnect():
     """Logout from GitHub and clear authentication session."""
     from commands.github import logout_command
 

--- a/cli/groups/local_group.py
+++ b/cli/groups/local_group.py
@@ -21,7 +21,7 @@ console = Console()
 local_app = typer.Typer(help="Local Docker development stack management")
 
 # Path to docker-compose file (relative to project root)
-COMPOSE_FILE = "docker-compose.nasiko.yml"
+COMPOSE_FILE = "docker-compose.local.yml"
 PROJECT_NAME = "nasiko"
 
 

--- a/cli/groups/local_group.py
+++ b/cli/groups/local_group.py
@@ -221,22 +221,28 @@ def local_up(
         console.print("\n[bold cyan]Starting Nasiko local development stack...[/]")
         console.print(f"[dim]Compose file: {COMPOSE_FILE}[/]\n")
 
-        # Remove stale containers that may conflict (from previous runs or other projects)
-        console.print("[dim]Removing stale containers...[/]")
-        stale = _compose_cmd_silent(["config", "--services"], check=False)
-        if stale.returncode == 0:
-            # Get container names from compose config
-            result_config = _compose_cmd_silent(["config"], check=False)
-            if result_config.returncode == 0:
-                # Extract container_name values and remove any that already exist
-                import re
+        # Remove only stopped/exited containers that may conflict — never kill running ones
+        console.print("[dim]Removing stale stopped containers...[/]")
+        result_config = _compose_cmd_silent(["config"], check=False)
+        if result_config.returncode == 0:
+            import re
 
-                container_names = re.findall(
-                    r"container_name:\s*(.+)", result_config.stdout
+            container_names = re.findall(
+                r"container_name:\s*(.+)", result_config.stdout
+            )
+            if container_names:
+                # Only remove containers that are not currently running
+                stopped = subprocess.run(
+                    ["docker", "ps", "-a", "--filter", "status=exited",
+                     "--filter", "status=created", "--filter", "status=dead",
+                     "--format", "{{.Names}}"],
+                    capture_output=True, text=True, check=False,
                 )
-                if container_names:
+                stopped_names = set(stopped.stdout.splitlines())
+                to_remove = [c for c in container_names if c in stopped_names]
+                if to_remove:
                     subprocess.run(
-                        ["docker", "rm", "-f"] + container_names,
+                        ["docker", "rm", "-f"] + to_remove,
                         capture_output=True,
                         check=False,
                     )
@@ -543,6 +549,125 @@ def local_deploy_agent(
     except Exception as e:
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)
+
+
+@local_app.command(name="init-superuser")
+def local_init_superuser(
+    auth_url: Annotated[
+        str,
+        typer.Option(
+            "--auth-url",
+            envvar="NASIKO_AUTH_URL",
+            help="Auth service URL",
+        ),
+    ] = "http://localhost:8082",
+    username: Annotated[
+        str,
+        typer.Option(envvar="NASIKO_SUPERUSER_USERNAME"),
+    ] = "admin",
+    email: Annotated[
+        str,
+        typer.Option(envvar="NASIKO_SUPERUSER_EMAIL"),
+    ] = "admin@nasiko.com",
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Delete existing superuser from MongoDB and recreate"),
+    ] = False,
+) -> None:
+    """Create or recreate the superuser for the local Docker stack."""
+    import json
+    import requests
+
+    _ensure_docker_running()
+
+    console.print(f"[cyan]Connecting to auth service at {auth_url}...[/]")
+
+    # Wait for auth service to be reachable
+    for attempt in range(10):
+        try:
+            r = requests.get(f"{auth_url}/health", timeout=5)
+            if r.status_code == 200:
+                break
+        except requests.RequestException:
+            pass
+        if attempt == 9:
+            console.print("[red]Error: Auth service is not reachable. Is the stack running?[/]")
+            console.print("Start it with: [cyan]nasiko local up[/]")
+            raise typer.Exit(1)
+        console.print(f"[dim]Waiting for auth service... ({attempt + 1}/10)[/]")
+        time.sleep(3)
+
+    def _register() -> None:
+        console.print(f"[cyan]Creating superuser '{username}'...[/]")
+        try:
+            response = requests.post(
+                f"{auth_url}/auth/users/register",
+                json={"username": username, "email": email, "is_super_user": True},
+                timeout=10,
+            )
+        except requests.RequestException as e:
+            console.print(f"[red]Error: Could not reach auth service: {e}[/]")
+            raise typer.Exit(1)
+
+        if response.status_code in (200, 201):
+            data = response.json()
+            access_key = data.get("access_key")
+            access_secret = data.get("access_secret")
+            user_id = data.get("user_id")
+
+            if not access_key or not access_secret:
+                console.print(f"[red]Unexpected response from auth service:[/] {data}")
+                raise typer.Exit(1)
+
+            project_root = _get_project_root()
+            creds_file = project_root / "orchestrator" / "superuser_credentials.json"
+            credentials = {
+                "user_id": user_id,
+                "username": username,
+                "email": email,
+                "access_key": access_key,
+                "access_secret": access_secret,
+                "is_super_user": True,
+                "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+            with open(creds_file, "w") as f:
+                json.dump(credentials, f, indent=2)
+
+            console.print("[green]✓ Superuser created successfully![/]")
+            console.print(f"\n  Access key:    [bold cyan]{access_key}[/]")
+            console.print(f"  Access secret: [bold cyan]{access_secret}[/]")
+            console.print(f"\n[dim]Credentials saved to: {creds_file}[/]")
+            console.print("\nLog in with: [cyan]nasiko auth login[/]")
+
+        elif response.status_code == 400 and "already exists" in response.text.lower():
+            console.print("[yellow]Superuser already exists.[/]")
+            console.print("Run with [cyan]--force[/] to delete and recreate.")
+            raise typer.Exit(0)
+        else:
+            console.print(f"[red]Auth service returned {response.status_code}:[/] {response.text}")
+            raise typer.Exit(1)
+
+    if force:
+        # Drop the user directly from MongoDB via docker exec
+        console.print(f"[yellow]--force: deleting existing superuser from MongoDB...[/]")
+        mongo_cmd = (
+            f"db.getSiblingDB('nasiko').users.deleteMany({{$or:[{{username:'{username}'}},{{email:'{email}'}}]}})"
+        )
+        result = subprocess.run(
+            ["docker", "exec", "mongodb", "mongosh",
+             "--username", "admin", "--password", "password",
+             "--authenticationDatabase", "admin",
+             "--eval", mongo_cmd],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            console.print(f"[red]Failed to delete user from MongoDB:[/] {result.stderr or result.stdout}")
+            raise typer.Exit(1)
+        console.print("[green]✓ Existing superuser removed.[/]")
+
+    _register()
 
 
 @local_app.command(name="shell")

--- a/cli/groups/observability_group.py
+++ b/cli/groups/observability_group.py
@@ -1,12 +1,15 @@
-"""Modern observability command group."""
+"""Observability command group (nasiko observe)."""
 
 import typer
 
-# Create Observability command group
-observability_app = typer.Typer(help="Observability and performance monitoring")
+# Canonical name: observe
+observe_app = typer.Typer(help="Observability and performance monitoring")
+
+# Backward-compat alias (registered as hidden in main.py)
+observability_app = observe_app
 
 
-@observability_app.command(name="sessions")
+@observe_app.command(name="sessions")
 def sessions(
     agent_id: str = typer.Argument(None, help="Agent ID to filter sessions (optional)"),
     days: int = typer.Option(
@@ -25,7 +28,7 @@ def sessions(
     sessions_command(agent_id, days, limit, format_type)
 
 
-@observability_app.command(name="session")
+@observe_app.command(name="session")
 def session_details(
     session_id: str = typer.Argument(..., help="Session ID to get details for"),
     format_type: str = typer.Option(
@@ -38,7 +41,7 @@ def session_details(
     session_details_command(session_id, format_type)
 
 
-@observability_app.command(name="trace")
+@observe_app.command(name="trace")
 def trace_details(
     project_id: str = typer.Argument(..., help="Project ID"),
     trace_id: str = typer.Argument(..., help="Trace ID to get details for"),
@@ -52,7 +55,7 @@ def trace_details(
     trace_details_command(project_id, trace_id, format_type)
 
 
-@observability_app.command(name="span")
+@observe_app.command(name="span")
 def span_details(
     span_id: str = typer.Argument(..., help="Span ID to get details for"),
     format_type: str = typer.Option(
@@ -65,7 +68,7 @@ def span_details(
     span_details_command(span_id, format_type)
 
 
-@observability_app.command(name="stats")
+@observe_app.command(name="stats")
 def agent_stats(
     agent_id: str = typer.Argument(..., help="Agent ID to get stats for"),
     days: int = typer.Option(

--- a/cli/main.py
+++ b/cli/main.py
@@ -248,6 +248,9 @@ def init_wizard():
             if e.code != 0:
                 console.print("[red]Failed to start local stack. Aborting.[/]")
                 raise typer.Exit(1)
+        except Exception as e:
+            console.print(f"[red]Failed to start local stack:[/] {e}")
+            raise typer.Exit(1)
 
         from setup.config import save_cluster_info
         save_cluster_info(
@@ -410,7 +413,7 @@ def register_groups():
     from groups.n8n_group import n8n_app
     from groups.chat_group import chat_app
     from groups.search_group import search_app
-    from groups.observability_group import observability_app
+    from groups.observability_group import observability_app, observe_app
     from groups.access_group import access_app
     from groups.user_group import user_app
     from groups.local_group import local_app
@@ -424,7 +427,8 @@ def register_groups():
     app.add_typer(n8n_app, name="n8n")
     app.add_typer(chat_app, name="chat")
     app.add_typer(search_app, name="search")
-    app.add_typer(observability_app, name="observability")
+    app.add_typer(observe_app, name="observe")
+    app.add_typer(observability_app, name="observability", hidden=True)  # backward compat
     app.add_typer(access_app, name="access")
     app.add_typer(user_app, name="user")
     app.add_typer(local_app, name="local")

--- a/cli/main.py
+++ b/cli/main.py
@@ -172,10 +172,9 @@ def use_cluster(
     known = {c["name"] for c in list_clusters()}
 
     if cluster not in known:
-        console.print(
-            f"[yellow]Warning:[/] cluster '{cluster}' not found in local state. "
-            "Setting it anyway — run [bold]nasiko cluster list[/] to verify."
-        )
+        console.print(f"[red]Cluster '{cluster}' not found.[/]")
+        console.print("Create it first with [bold]nasiko init[/] or [bold]nasiko cluster create[/], then switch to it.")
+        raise typer.Exit(1)
 
     set_active_cluster(cluster)
     console.print(f"[green]Active cluster:[/] [bold]{cluster}[/]")
@@ -233,10 +232,57 @@ def init_wizard():
         default="remote",
     )
 
-    if cluster_type in ("local", "local-k8s"):
-        console.print(f"[yellow]'{cluster_type}' cluster support is not yet implemented.[/]")
-        console.print("Stay tuned for a future release.")
+    if cluster_type == "local-k8s":
+        console.print("[yellow]'local-k8s' (kind/minikube) support is not yet implemented.[/]")
         raise typer.Exit(0)
+
+    if cluster_type == "local":
+        cluster_name = typer.prompt("Cluster name", default="local")
+        console.print("\n[bold]Step 1:[/] Starting local Docker Compose stack...")
+        try:
+            from groups.local_group import _ensure_docker_running, _ensure_docker_compose, local_up
+            _ensure_docker_running()
+            _ensure_docker_compose()
+            local_up()
+        except SystemExit as e:
+            if e.code != 0:
+                console.print("[red]Failed to start local stack. Aborting.[/]")
+                raise typer.Exit(1)
+
+        from setup.config import save_cluster_info
+        save_cluster_info(
+            provider="local",
+            cluster_name=cluster_name,
+            data={"gateway_url": "http://localhost:9100", "type": "docker-compose"},
+        )
+        set_active_cluster(cluster_name)
+        console.print(f"\n[green]Active cluster set to:[/] [bold]{cluster_name}[/]")
+        console.print("[dim]API URL: http://localhost:9100[/]")
+
+        if typer.confirm("\nWould you like to log in now?", default=True):
+            access_key = typer.prompt("Access key")
+            access_secret = typer.prompt("Access secret", hide_input=True)
+            auth_manager = get_auth_manager(cluster_name=cluster_name)
+            if auth_manager.login(access_key, access_secret):
+                console.print("[green]Login successful![/]")
+            else:
+                console.print("[yellow]Login failed.[/] Try [bold]nasiko auth login[/] once the stack is ready.")
+        else:
+            console.print("Log in later with [bold]nasiko auth login[/].")
+
+        # Optional: GitHub OAuth setup
+        console.print()
+        if typer.confirm("Would you like to set up GitHub integration? (lets you deploy agents from GitHub repos)", default=False):
+            console.print("\n[bold]To enable GitHub integration:[/bold]")
+            console.print("1. Go to [cyan]https://github.com/settings/developers[/cyan] → OAuth Apps → New OAuth App")
+            console.print(f"   Homepage URL:  [cyan]http://localhost:9100[/cyan]")
+            console.print(f"   Callback URL:  [cyan]http://localhost:9100/auth/github/callback[/cyan]")
+            console.print("2. Add to your env file:")
+            console.print("   [dim]GITHUB_CLIENT_ID=your_client_id[/dim]")
+            console.print("   [dim]GITHUB_CLIENT_SECRET=your_client_secret[/dim]")
+            console.print("3. Restart: [cyan]nasiko local down && nasiko local up[/cyan]")
+            console.print("4. Then run: [cyan]nasiko github connect[/cyan]")
+        return
 
     # --- Remote cluster setup ---
     provider = typer.prompt(
@@ -305,11 +351,16 @@ def init_wizard():
 
 
 @app.command(name="docs")
-def api_docs():
-    """Get API documentation and Swagger links."""
-    from commands.registry import api_docs_command
+def docs_command(
+    topic: str = typer.Argument(
+        None,
+        help="Topic: install, quickstart, concepts, auth, cluster, github, agent, chat, observability, access, local, n8n, images, user, search, env",
+    ),
+):
+    """CLI documentation. Run without arguments for an overview, or specify a topic."""
+    from commands.cli_docs import show_docs
 
-    api_docs_command()
+    show_docs(topic)
 
 
 @app.command(name="list-clusters")

--- a/cli/main.py
+++ b/cli/main.py
@@ -151,52 +151,157 @@ def callback(
     """Main CLI entry point."""
     if cluster:
         os.environ["NASIKO_CLUSTER_NAME"] = cluster
-    pass
+    elif not os.environ.get("NASIKO_CLUSTER_NAME"):
+        # Fall back to active cluster stored in context.json
+        from core.context import get_active_cluster
+        active = get_active_cluster()
+        if active:
+            os.environ["NASIKO_CLUSTER_NAME"] = active
 
 
-# Top-level Authentication Commands (for convenience)
-@app.command(name="login")
-def login_cmd(
-    access_key: str = typer.Option(
-        ..., "--access-key", "-k", prompt="Access Key", help="Your access key"
-    ),
-    access_secret: str = typer.Option(
-        ...,
-        "--access-secret",
-        "-s",
-        prompt="Access Secret",
-        hide_input=True,
-        help="Your access secret",
-    ),
+@app.command(name="use")
+def use_cluster(
+    cluster: str = typer.Argument(..., help="Cluster name to set as active"),
 ):
-    """Login to Nasiko."""
-    from auth.auth_commands import login_standalone
+    """Set the active cluster for subsequent commands (like 'git checkout')."""
+    from rich.console import Console
+    from setup.config import list_clusters
+    from core.context import set_active_cluster
 
-    login_standalone(access_key, access_secret)
+    console = Console()
+    known = {c["name"] for c in list_clusters()}
 
+    if cluster not in known:
+        console.print(
+            f"[yellow]Warning:[/] cluster '{cluster}' not found in local state. "
+            "Setting it anyway — run [bold]nasiko cluster list[/] to verify."
+        )
 
-@app.command(name="logout")
-def logout_cmd():
-    """Logout from Nasiko."""
-    from auth.auth_commands import logout_command
-
-    logout_command()
-
-
-@app.command(name="status")
-def auth_status_cmd():
-    """Check authentication status."""
-    from auth.auth_commands import status_command
-
-    status_command()
+    set_active_cluster(cluster)
+    console.print(f"[green]Active cluster:[/] [bold]{cluster}[/]")
 
 
-@app.command(name="whoami")
-def whoami_cmd():
-    """Show current user information."""
-    from auth.auth_commands import whoami_command
+@app.command(name="current")
+def current_cluster():
+    """Show the active cluster, its API URL, and auth status."""
+    from rich.console import Console
+    from setup.config import get_cluster_api_url
+    from auth.auth_manager import get_auth_manager
+    from core.context import get_active_cluster
 
-    whoami_command()
+    console = Console()
+    name = get_active_cluster()
+
+    if not name:
+        console.print("[yellow]No active cluster set.[/]")
+        console.print("Run [bold]nasiko use <cluster>[/] or [bold]nasiko init[/] to get started.")
+        raise typer.Exit(1)
+
+    api_url = get_cluster_api_url(name) or "(not found in local state)"
+    auth_manager = get_auth_manager(cluster_name=name)
+    logged_in = auth_manager.is_logged_in()
+    auth_status = "[green]logged in[/]" if logged_in else "[red]not logged in[/]"
+
+    console.print(f"[bold]Active cluster:[/] {name}")
+    console.print(f"[bold]API URL:[/]        {api_url}")
+    console.print(f"[bold]Auth:[/]           {auth_status}")
+
+
+@app.command(name="init")
+def init_wizard():
+    """First-run wizard: create a cluster, set it active, and log in."""
+    from rich.console import Console
+    from rich.panel import Panel
+    from setup.config import get_cluster_api_url
+    from core.context import set_active_cluster
+    from auth.auth_manager import get_auth_manager
+
+    console = Console()
+
+    console.print(Panel.fit(
+        "[bold cyan]Welcome to Nasiko![/]\n"
+        "This wizard will help you set up your first cluster.",
+        title="nasiko init",
+        border_style="cyan",
+    ))
+
+    import click
+
+    cluster_type = typer.prompt(
+        "Cluster type",
+        type=click.Choice(["remote", "local", "local-k8s"]),
+        default="remote",
+    )
+
+    if cluster_type in ("local", "local-k8s"):
+        console.print(f"[yellow]'{cluster_type}' cluster support is not yet implemented.[/]")
+        console.print("Stay tuned for a future release.")
+        raise typer.Exit(0)
+
+    # --- Remote cluster setup ---
+    provider = typer.prompt(
+        "Cloud provider",
+        type=click.Choice(["aws", "digitalocean"]),
+        default="aws",
+    )
+    cluster_name = typer.prompt("Cluster name", default="nasiko")
+    region = typer.prompt("Region (e.g. us-east-1, nyc3)", default="").strip() or None
+
+    # Step 1: init-modules
+    console.print("\n[bold]Step 1:[/] Initialising Terraform modules...")
+    try:
+        from setup.k8s_setup import init_modules
+        init_modules(source=None, force=False)
+    except SystemExit as e:
+        if e.code != 0:
+            console.print("[red]Module initialisation failed. Aborting.[/]")
+            raise typer.Exit(1)
+
+    # Step 2: create remote cluster
+    console.print("\n[bold]Step 2:[/] Creating remote cluster (this may take several minutes)...")
+    try:
+        from setup.k8s_setup import create, Provider
+        create(
+            provider=Provider(provider),
+            cluster_name=cluster_name,
+            region=region,
+            node_size=None,
+            auto_approve=False,
+            verbose=False,
+            terraform_dir=None,
+            state_dir=None,
+        )
+    except SystemExit as e:
+        if e.code != 0:
+            console.print("[red]Cluster creation failed. Aborting.[/]")
+            raise typer.Exit(1)
+
+    # Set new cluster as active
+    set_active_cluster(cluster_name)
+    console.print(f"\n[green]Active cluster set to:[/] [bold]{cluster_name}[/]")
+
+    # Offer login
+    api_url = get_cluster_api_url(cluster_name)
+    if not api_url:
+        console.print(
+            "\n[yellow]Cluster API URL not yet available.[/] "
+            "Run [bold]nasiko cluster output[/] once provisioning completes, "
+            "then [bold]nasiko auth login[/]."
+        )
+        return
+
+    if typer.confirm("\nWould you like to log in now?", default=True):
+        access_key = typer.prompt("Access key")
+        access_secret = typer.prompt("Access secret", hide_input=True)
+        auth_manager = get_auth_manager(cluster_name=cluster_name)
+        if auth_manager.login(access_key, access_secret):
+            console.print("[green]Login successful![/] You're ready to use Nasiko.")
+        else:
+            console.print(
+                "[yellow]Login failed.[/] Try [bold]nasiko auth login[/] once the cluster is fully ready."
+            )
+    else:
+        console.print("You can log in later with [bold]nasiko auth login[/].")
 
 
 @app.command(name="docs")
@@ -247,6 +352,8 @@ app.add_typer(
 # Import and register command groups
 def register_groups():
     """Register all command groups."""
+    from auth.auth_commands import auth_app
+    from groups.cluster_group import cluster_app
     from groups.github_group import github_app
     from groups.agent_group import agent_app
     from groups.n8n_group import n8n_app
@@ -259,6 +366,8 @@ def register_groups():
     from groups.images_group import images_app
 
     # Add groups to main app
+    app.add_typer(auth_app, name="auth")
+    app.add_typer(cluster_app, name="cluster")
     app.add_typer(github_app, name="github")
     app.add_typer(agent_app, name="agent")
     app.add_typer(n8n_app, name="n8n")

--- a/cli/setup/k8s_setup.py
+++ b/cli/setup/k8s_setup.py
@@ -473,7 +473,7 @@ def destroy(
         console.print(
             f"[yellow]No state found for cluster '{cluster_name}' ({provider.value})[/]"
         )
-        console.print("[yellow]Use 'nasiko setup k8s list' to see managed clusters[/]")
+        console.print("[yellow]Use 'nasiko cluster list' to see managed clusters[/]")
         raise typer.Exit(code=1)
 
     work_dir = state_info["work_dir"]
@@ -563,7 +563,7 @@ def list_clusters(
     if not clusters:
         console.print("[yellow]No managed clusters found.[/]")
         console.print(
-            "[dim]Create a cluster with: nasiko setup k8s create <provider>[/]"
+            "[dim]Create a cluster with: nasiko cluster create remote --provider <provider>[/]"
         )
         return
 
@@ -639,7 +639,7 @@ def init_modules(
     directory structure (for development) or prompt for a path.
 
     Example:
-        nasiko setup k8s init-modules --source /path/to/terraform
+        nasiko cluster init-modules --source /path/to/terraform
     """
 
     console.print("[cyan]Initializing Terraform modules...[/]\n")
@@ -664,7 +664,7 @@ def init_modules(
     if not aws_exists or not do_exists:
         console.print("\n[yellow]Some modules are missing. Provide the source path:[/]")
         console.print(
-            "[dim]  nasiko setup k8s init-modules --source /path/to/terraform[/]"
+            "[dim]  nasiko cluster init-modules --source /path/to/terraform[/]"
         )
 
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,8 +21,9 @@ services:
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
       interval: 30s
-      timeout: 10s
-      retries: 3
+      timeout: 30s
+      retries: 5
+      start_period: 30s
 
   redis:
     image: redis:7-alpine

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,119 +1,180 @@
 # Getting Started with Nasiko
 
-This guide picks up where the [README](../README.md) leaves off. It assumes you've already completed the setup steps there and have Nasiko running at `http://localhost:9100/app/`.
+This guide walks you through logging in, deploying your first agent, and chatting with it — entirely from the CLI.
 
-If you haven't done that yet, follow the [Quick Start](../README.md#-quick-start) instructions first, then come back here.
+If you haven't installed the CLI yet, see [CLI Tool](../README.md#️-cli-tool) in the README.
 
-## First Login
+---
 
-Nasiko automatically creates a superuser account during setup and writes the credentials to a local file.
+## 1. Set Up Your Cluster
 
-### 1. Find Your Credentials
+### Local (Docker Compose) — recommended for first-timers
 
 ```bash
-cat orchestrator/superuser_credentials.json
+nasiko init
+# Cluster type: local
+# Cluster name: local  (or any name you like)
 ```
 
-You'll see something like:
+This starts the Docker Compose stack and sets it as the active cluster.
 
-```json
-{
-  "email": "admin@example.com",
-  "username": "admin",
-  "access_key": "your-access-key-here",
-  "access_secret": "your-access-secret-here",
-  "created_at": "2026-02-25T10:30:00Z"
-}
+### Connect to an existing cluster
+
+```bash
+nasiko cluster connect prod --url https://api.my-cluster.example.com
+nasiko use prod
 ```
 
-### 2. Sign In
+---
 
-1. Go to http://localhost:9100/app/
-2. Enter the **Access Key** and **Access Secret** from the credentials file
-3. Click **Sign In**
+## 2. Log In
 
-You should land on the Home dashboard.
+```bash
+nasiko auth login
+# Access Key:    NASK_xxxx
+# Access Secret: ****
+```
 
-## Deploy Your First Agent
+### Getting credentials
 
-The repo ships with pre-built agent ZIP files you can use to verify the platform is working. We'll use the translator agent.
+If this is a fresh local stack, register the superuser first:
 
-### 1. Upload the Agent
+```bash
+nasiko cluster init-superuser --superuser-username admin --superuser-email admin@nasiko.com
+```
 
-1. In the sidebar, click **"Add Agent"**
-2. Select **"Upload ZIP"**
-3. Click **"Choose File"** and select `agents/a2a-translator.zip` from your Nasiko directory
-4. Click **"Upload"**
+> **Note:** `init-superuser` requires `--kubeconfig` for remote (k8s) clusters. For local Docker Compose, register via the auth service directly:
+> ```bash
+> curl -s -X POST http://localhost:8082/auth/users/register \
+>   -H "Content-Type: application/json" \
+>   -d '{"username":"admin","email":"admin@nasiko.com","is_super_user":true}'
+> ```
+> Use the returned `access_key` and `access_secret` to log in.
 
-### 2. Wait for Deployment
+Verify you're logged in:
 
-Go to **"Your Agents"** in the sidebar to watch progress. You'll see the agent move through these stages:
+```bash
+nasiko current
+# Active cluster: local
+# API URL:        http://localhost:9100
+# Auth:           logged in
+```
 
-- **Setting Up** — Upload received, container is being built
-- **Active** — Agent is running and ready for queries
-- **Failed** — Something went wrong (see [Troubleshooting](../README.md#-troubleshooting) in the README)
+---
+
+## 3. Deploy Your First Agent
+
+The repo ships with pre-built agents in the `agents/` directory.
+
+```bash
+# From a directory
+nasiko agent deploy ./agents/a2a-translator
+
+# From a zip file
+nasiko agent deploy ./agents/a2a-translator.zip
+
+# From GitHub (requires nasiko github connect)
+nasiko agent deploy owner/repo-name
+```
+
+Watch the status:
+
+```bash
+nasiko agent list-uploaded
+# Shows: Setting Up → Active
+```
 
 Local deployment typically takes 1–2 minutes.
 
-### 3. Verify It's Running
+---
 
-Once the status shows **Active**, go back to the **Home** dashboard. You should see the translator agent card listed there.
+## 4. Chat with the Agent
 
-You can also verify from the command line:
-
-```bash
-# Check the agent is registered and accessible through Kong
-curl http://localhost:9100/agents/translator/health
-```
-
-## Test the Agent
-
-### 1. Start a Session
-
-On the Home dashboard, find the **translator** agent card and click **"Start Session"**. This opens the interaction interface.
-
-### 2. Send Some Queries
-
-Try these:
-
-```
-Translate "Hello, how are you?" to French
-```
-
-```
-Convert this text to Spanish: "The weather is beautiful today"
-```
-
-```
-Translate the following to German: "Thank you for your help"
-```
-
-Responses appear in real-time, and conversation history is saved automatically.
-
-### 3. Try the Router
-
-Instead of talking to a specific agent, you can let the router pick the best agent for a query:
+### Interactive mode (recommended)
 
 ```bash
-curl "http://localhost:9100/router/route?query=translate this to French"
+nasiko chat start "Translator Agent"
 ```
 
-The router analyzes the query, matches it against agent capabilities defined in each agent's `AgentCard.json`, and returns the best match with a confidence score.
+You'll enter a live conversation loop:
+
+```
+╭─────────────────────────────────────╮
+│ Chatting with: Translator Agent     │
+│ Type 'exit' or Ctrl+C to quit       │
+╰─────────────────────────────────────╯
+
+You: Translate "Hello world" to French
+Agent Reply: Bonjour le monde
+
+You: Now to Spanish
+Agent Reply: Hola mundo
+
+You: exit
+```
+
+### One-shot message
+
+```bash
+# Get the agent URL first
+nasiko agent get --name "Translator Agent"
+
+# Create a session
+nasiko chat sessions
+
+# Send a message
+nasiko chat send \
+  --url <agent-url> \
+  --session-id <session-id> \
+  --message "Translate to French: Good morning"
+```
+
+---
+
+## 5. Observe What's Happening
+
+```bash
+nasiko observe sessions                   # all recent sessions
+nasiko observe sessions <agent_id>        # filtered by agent
+nasiko observe stats <agent_id>           # performance summary
+```
+
+---
 
 ## Next Steps
 
-**Deploy more agents.** The `agents/` directory includes additional examples:
-- `a2a-compliance-checker` — Document policy compliance analysis
-- `a2a-github-agent` — GitHub repository operations
-
-Upload them the same way (Add Agent → Upload ZIP), or use the CLI:
-
+**Deploy more agents:**
 ```bash
-nasiko agent upload-directory ./agents/a2a-compliance-checker --name compliance
+nasiko agent deploy ./agents/a2a-compliance-checker
+nasiko agent deploy ./agents/a2a-github-agent
 ```
 
-**Check observability.** Open [Phoenix](http://localhost:6006) to see traces, API call timing, and conversation patterns for your deployed agents.
+**Switch clusters:**
+```bash
+nasiko use prod-aws
+nasiko agent list          # now listing prod-aws agents
+nasiko use local           # switch back
+```
 
-**Build your own agent.** See the [Agent Development](../README.md#-agent-development) section in the README for the required file structure, `AgentCard.json` format, and a complete code example.
+**Manage users (super user only):**
+```bash
+nasiko admin user register --username alice --email alice@example.com
+nasiko admin user list
+nasiko admin search users alice
+```
 
-**Set up the CLI.** The CLI gives you full platform management from the terminal. See [CLI Tool](../README.md#️-cli-tool) in the README for installation and usage.
+**Connect GitHub to deploy from repos:**
+```bash
+nasiko github connect
+nasiko github repos
+nasiko agent deploy owner/my-agent-repo
+```
+
+**Full CLI reference:**
+```bash
+nasiko docs                # overview
+nasiko docs agent          # agent commands
+nasiko docs chat           # chat commands
+nasiko docs cluster        # cluster lifecycle
+nasiko docs observe        # observability
+```

--- a/nasiko-pkg/pyproject.toml
+++ b/nasiko-pkg/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nasiko"
+version = "0.0.1"
+description = "Nasiko - Build, deploy, and manage AI agents"
+license = "MIT"
+authors = [
+    {name = "Nasiko Team"},
+]
+requires-python = ">=3.9"
+dependencies = [
+    "nasiko-cli>=2.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/arithmic/nasiko"
+Repository = "https://github.com/arithmic/nasiko"
+
+[tool.setuptools]
+packages = []

--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,6 @@ dependencies = [
     { name = "astor" },
     { name = "autogen" },
     { name = "beautifulsoup4" },
-    { name = "black" },
     { name = "boto3" },
     { name = "chromadb" },
     { name = "click" },
@@ -427,7 +426,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "black" },
+    { name = "mypy" },
     { name = "pyinstaller" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -442,7 +444,6 @@ requires-dist = [
     { name = "astor", specifier = ">=0.8.1" },
     { name = "autogen", specifier = ">=0.9.9" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
-    { name = "black", specifier = ">=25.1.0" },
     { name = "boto3", specifier = ">=1.38.0" },
     { name = "chromadb", specifier = ">=1.0.20" },
     { name = "click", specifier = ">=8.2.1" },
@@ -497,7 +498,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pyinstaller", specifier = ">=6.17.0" }]
+dev = [
+    { name = "black", specifier = "==26.3.1" },
+    { name = "mypy", specifier = ">=1.0.0" },
+    { name = "pyinstaller", specifier = ">=6.17.0" },
+    { name = "ruff", specifier = ">=0.8.0" },
+]
 
 [[package]]
 name = "arize-phoenix"
@@ -804,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "26.1.0"
+version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -814,24 +820,24 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", size = 658785, upload-time = "2026-01-18T04:50:11.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/13/710298938a61f0f54cdb4d1c0baeb672c01ff0358712eddaf29f76d32a0b/black-26.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6eeca41e70b5f5c84f2f913af857cf2ce17410847e1d54642e658e078da6544f", size = 1878189, upload-time = "2026-01-18T04:59:30.682Z" },
-    { url = "https://files.pythonhosted.org/packages/79/a6/5179beaa57e5dbd2ec9f1c64016214057b4265647c62125aa6aeffb05392/black-26.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dd39eef053e58e60204f2cdf059e2442e2eb08f15989eefe259870f89614c8b6", size = 1700178, upload-time = "2026-01-18T04:59:32.387Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/04/c96f79d7b93e8f09d9298b333ca0d31cd9b2ee6c46c274fd0f531de9dc61/black-26.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9459ad0d6cd483eacad4c6566b0f8e42af5e8b583cee917d90ffaa3778420a0a", size = 1777029, upload-time = "2026-01-18T04:59:33.767Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f9/71c161c4c7aa18bdda3776b66ac2dc07aed62053c7c0ff8bbda8c2624fe2/black-26.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:a19915ec61f3a8746e8b10adbac4a577c6ba9851fa4a9e9fbfbcf319887a5791", size = 1406466, upload-time = "2026-01-18T04:59:35.177Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/8b/a7b0f974e473b159d0ac1b6bcefffeb6bec465898a516ee5cc989503cbc7/black-26.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:643d27fb5facc167c0b1b59d0315f2674a6e950341aed0fc05cf307d22bf4954", size = 1216393, upload-time = "2026-01-18T04:59:37.18Z" },
-    { url = "https://files.pythonhosted.org/packages/79/04/fa2f4784f7237279332aa735cdfd5ae2e7730db0072fb2041dadda9ae551/black-26.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ba1d768fbfb6930fc93b0ecc32a43d8861ded16f47a40f14afa9bb04ab93d304", size = 1877781, upload-time = "2026-01-18T04:59:39.054Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/ad/5a131b01acc0e5336740a039628c0ab69d60cf09a2c87a4ec49f5826acda/black-26.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2b807c240b64609cb0e80d2200a35b23c7df82259f80bef1b2c96eb422b4aac9", size = 1699670, upload-time = "2026-01-18T04:59:41.005Z" },
-    { url = "https://files.pythonhosted.org/packages/da/7c/b05f22964316a52ab6b4265bcd52c0ad2c30d7ca6bd3d0637e438fc32d6e/black-26.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1de0f7d01cc894066a1153b738145b194414cc6eeaad8ef4397ac9abacf40f6b", size = 1775212, upload-time = "2026-01-18T04:59:42.545Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/a3/e8d1526bea0446e040193185353920a9506eab60a7d8beb062029129c7d2/black-26.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:91a68ae46bf07868963671e4d05611b179c2313301bd756a89ad4e3b3db2325b", size = 1409953, upload-time = "2026-01-18T04:59:44.357Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5a/d62ebf4d8f5e3a1daa54adaab94c107b57be1b1a2f115a0249b41931e188/black-26.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:be5e2fe860b9bd9edbf676d5b60a9282994c03fbbd40fe8f5e75d194f96064ca", size = 1217707, upload-time = "2026-01-18T04:59:45.719Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/83/be35a175aacfce4b05584ac415fd317dd6c24e93a0af2dcedce0f686f5d8/black-26.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9dc8c71656a79ca49b8d3e2ce8103210c9481c57798b48deeb3a8bb02db5f115", size = 1871864, upload-time = "2026-01-18T04:59:47.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/f5/d33696c099450b1274d925a42b7a030cd3ea1f56d72e5ca8bbed5f52759c/black-26.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b22b3810451abe359a964cc88121d57f7bce482b53a066de0f1584988ca36e79", size = 1701009, upload-time = "2026-01-18T04:59:49.443Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/87/670dd888c537acb53a863bc15abbd85b22b429237d9de1b77c0ed6b79c42/black-26.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53c62883b3f999f14e5d30b5a79bd437236658ad45b2f853906c7cbe79de00af", size = 1767806, upload-time = "2026-01-18T04:59:50.769Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9c/cd3deb79bfec5bcf30f9d2100ffeec63eecce826eb63e3961708b9431ff1/black-26.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:f016baaadc423dc960cdddf9acae679e71ee02c4c341f78f3179d7e4819c095f", size = 1433217, upload-time = "2026-01-18T04:59:52.218Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/29/f3be41a1cf502a283506f40f5d27203249d181f7a1a2abce1c6ce188035a/black-26.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:66912475200b67ef5a0ab665011964bf924745103f51977a78b4fb92a9fc1bf0", size = 1245773, upload-time = "2026-01-18T04:59:54.457Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3d/51bdb3ecbfadfaf825ec0c75e1de6077422b4afa2091c6c9ba34fbfc0c2d/black-26.1.0-py3-none-any.whl", hash = "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede", size = 204010, upload-time = "2026-01-18T04:50:09.978Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -3123,6 +3129,66 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.81.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3640,6 +3706,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
 ]
 
 [[package]]
@@ -5742,6 +5841,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Auth group** — `nasiko auth login/logout/status` replacing old flat commands; per-cluster token storage so switching clusters doesn't require re-login
- **Cluster group** — `nasiko cluster connect/create/list/destroy/bootstrap` unified under one group; `cluster connect` supports `--auth key|github|digitalocean` for SSO flows
- **Context management** — `nasiko use <cluster>` and `nasiko current` for switching/inspecting active cluster; state persisted in `~/.nasiko/context.json`
- **GitHub** — `nasiko github connect/disconnect/status`; preflight 404 detection with setup instructions; SSO flow works without prior Nasiko auth
- **Agent** — `nasiko agent deploy` smart-routes directory, zip, or GitHub repo; `nasiko agent n8n` sub-group absorbs N8N workflow commands
- **Chat** — `nasiko chat start <agent>` enters interactive loop (no session ID / URL needed); `sessions`, `drop` renames
- **nasiko init wizard** — interactive setup for local (Docker Compose) and remote (AWS/DO) clusters
- **nasiko docs** — full terminal documentation with topic navigation (`nasiko docs quickstart`, `nasiko docs cluster`, etc.)
- **API client** — URL builder always routes through `/api/v1/`; per-cluster auth manager instances with isolated token storage

## Test plan

- [ ] `nasiko auth login` / `nasiko auth logout` / `nasiko auth status` on a live remote cluster
- [ ] `nasiko cluster connect <name> --url <url>` with `--auth key` and `--auth github`
- [ ] `nasiko cluster list` shows connected clusters with active marker
- [ ] `nasiko use <cluster>` / `nasiko current` switches context correctly
- [ ] `nasiko agent list` works after switching clusters without re-login
- [ ] `nasiko agent deploy .` deploys from current directory
- [ ] `nasiko chat start "Agent Name"` enters interactive chat loop
- [ ] `nasiko github status` returns correct state per cluster
- [ ] `nasiko docs` / `nasiko docs quickstart` renders without errors
