### PR TITLE
update nasiko-web docker tag

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -311,7 +311,7 @@ services:
   # WEB FRONTEND LAYER
   # ============================================================================
   nasiko-web:
-    image: docker.io/karannasiko/nasiko-web:latest
+    image: docker.io/karannasiko/nasiko-web:oss
     platform: linux/amd64
     container_name: nasiko-web
     restart: unless-stopped


### PR DESCRIPTION
The updated image was not being pulled from nasiko-web/latest, it is tagged as /oss
We need to make sure we tag updated images to match docker-compose.local.yml in the future