### PR TITLE
feat: add request management layer between Kong and agents

### DIFF
--- a/agent-gateway/registry/registry.py
+++ b/agent-gateway/registry/registry.py
@@ -48,6 +48,12 @@ if not K8S_ENABLED:
 else:
     logger.info("K8S_ENABLED=true; Using Kubernetes service discovery")
 
+# When set, all agent traffic is routed through the request manager for
+# caching, rate limiting, and queueing. Set to "" to bypass.
+REQUEST_MANAGER_URL = os.environ.get(
+    "REQUEST_MANAGER_URL", "http://nasiko-request-manager:8090"
+).rstrip("/")
+
 # FastAPI app for health checks and status
 app = FastAPI(
     title="Kong Service Registry",
@@ -280,6 +286,8 @@ def get_docker_services() -> List[ServiceInfo]:
                     "nasiko-router",
                     "nasiko-auth-service",
                     "nasiko-chat-history",
+                    "nasiko-request-manager",
+                    "nasiko-redis",
                     "redis",
                     "mongodb",
                     "phoenix-observability",
@@ -331,7 +339,10 @@ def register_service_in_kong(service: ServiceInfo) -> bool:
     """Register a service and route in Kong."""
     try:
         # Create service in Kong
-        service_url = f"http://{service.host}:{service.port}"
+        if REQUEST_MANAGER_URL:
+            service_url = f"{REQUEST_MANAGER_URL}/proxy/{service.host}/{service.port}"
+        else:
+            service_url = f"http://{service.host}:{service.port}"
 
         service_data = {
             "name": service.name,

--- a/agent-gateway/request-manager/Dockerfile
+++ b/agent-gateway/request-manager/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir \
+    fastapi \
+    "uvicorn[standard]" \
+    httpx \
+    "redis>=6.4.0" \
+    pydantic \
+    "pydantic-settings>=2.0.0" \
+    python-json-logger \
+    opentelemetry-sdk \
+    opentelemetry-exporter-otlp-proto-grpc
+
+COPY src/ ./src/
+
+EXPOSE 8090
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8090"]

--- a/agent-gateway/request-manager/pyproject.toml
+++ b/agent-gateway/request-manager/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "nasiko-request-manager"
+version = "1.0.0"
+description = "Request management layer: caching, rate limiting, and queueing for Nasiko agent traffic"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.104.1",
+    "uvicorn[standard]>=0.24.0",
+    "httpx>=0.25.0",
+    "redis>=6.4.0",
+    "pydantic>=2.5.0",
+    "pydantic-settings>=2.0.0",
+    "python-json-logger>=2.0.7",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/agent-gateway/request-manager/src/cache.py
+++ b/agent-gateway/request-manager/src/cache.py
@@ -1,0 +1,235 @@
+import copy
+import hashlib
+import json
+import logging
+import time
+from typing import Optional
+
+import redis.asyncio as aioredis
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+CACHE_NS = "rm:cache"
+CACHE_STATS_NS = "rm:cstats"
+REQ_LOG_NS = "rm:reqlog"
+REQ_LOG_MAX = 100  # entries kept per agent
+
+
+def _normalize_body(body: dict) -> str:
+    """
+    Canonical JSON string for cache keying.
+    Strips volatile messageId (changes per UI call, doesn't affect agent answer).
+    Sorts all keys for deterministic serialisation.
+    """
+    normalized = copy.deepcopy(body)
+    normalized.pop("id", None)  # JSON-RPC request id is volatile
+    params = normalized.get("params", {})
+    message = params.get("message", {})
+    message.pop("messageId", None)
+    for part in message.get("parts", []):
+        if "text" in part:
+            part["text"] = part["text"].strip().lower()
+    return json.dumps(normalized, sort_keys=True, ensure_ascii=False)
+
+
+def build_cache_key(agent_name: str, body: dict) -> str:
+    canonical = _normalize_body(body)
+    digest = hashlib.sha256(f"{agent_name}:{canonical}".encode()).hexdigest()
+    return f"{CACHE_NS}:{agent_name}:{digest}"
+
+
+def extract_query_text(body: dict) -> str:
+    """Pull the human-readable query out of a JSON-RPC message/send body."""
+    try:
+        parts = body.get("params", {}).get("message", {}).get("parts", [])
+        return " ".join(p["text"] for p in parts if "text" in p).strip()
+    except Exception:
+        return ""
+
+
+def _parts_text(parts: list) -> str:
+    """Flatten a parts array to a single lowercase string for comparison."""
+    return " ".join(
+        p.get("text", "") for p in parts if isinstance(p, dict) and "text" in p
+    ).strip().lower()
+
+
+def deduplicate_history(body: dict) -> dict:
+    """
+    Scan known history fields in the request body and remove earlier duplicate
+    (user_query, assistant_response) pairs, keeping only the latest occurrence.
+
+    Supports field names: history, messages, conversation, context_messages.
+    A pair is considered duplicate when both the user text and the immediately
+    following assistant text are identical (case-insensitive).
+
+    Returns a new body dict (original is not mutated).
+    """
+    HISTORY_FIELDS = ("history", "messages", "conversation", "context_messages")
+
+    def _find_history_path(d: dict) -> tuple[dict, str] | None:
+        """Return (container_dict, field_name) for the first history array found."""
+        for field in HISTORY_FIELDS:
+            if isinstance(d.get(field), list):
+                return d, field
+        params = d.get("params", {})
+        if isinstance(params, dict):
+            for field in HISTORY_FIELDS:
+                if isinstance(params.get(field), list):
+                    return params, field
+        return None
+
+    location = _find_history_path(body)
+    if location is None:
+        return body
+
+    container, field = location
+    history: list = container[field]
+    if len(history) < 4:  # need at least 2 pairs to deduplicate
+        return body
+
+    # Build (user_text, assistant_text) pairs with their index ranges
+    seen: dict[tuple[str, str], int] = {}  # pair -> index of user message
+    i = 0
+    indices_to_drop: set[int] = set()
+
+    while i < len(history):
+        msg = history[i]
+        if not isinstance(msg, dict):
+            i += 1
+            continue
+        role = msg.get("role", "")
+        if role == "user" and i + 1 < len(history):
+            next_msg = history[i + 1]
+            if isinstance(next_msg, dict) and next_msg.get("role") in ("assistant", "agent", "model"):
+                u_text = _parts_text(msg.get("parts", [])) or msg.get("content", "").strip().lower()
+                a_text = _parts_text(next_msg.get("parts", [])) or next_msg.get("content", "").strip().lower()
+                pair = (u_text, a_text)
+                if pair in seen:
+                    indices_to_drop.add(seen[pair])
+                    indices_to_drop.add(seen[pair] + 1)
+                seen[pair] = i
+                i += 2
+                continue
+        i += 1
+
+    if not indices_to_drop:
+        return body
+
+    new_history = [msg for idx, msg in enumerate(history) if idx not in indices_to_drop]
+    new_body = copy.deepcopy(body)
+    if container is body.get("params", {}):
+        new_body["params"][field] = new_history
+    else:
+        new_body[field] = new_history
+    return new_body
+
+
+class CacheManager:
+    def __init__(self, redis_client: aioredis.Redis):
+        self._r = redis_client
+
+    async def get(self, key: str, agent_name: str) -> Optional[str]:
+        val = await self._r.get(key)
+        stats_key = f"{CACHE_STATS_NS}:{agent_name}"
+        if val is not None:
+            await self._r.hincrby(stats_key, "hits", 1)
+            logger.debug(f"Cache HIT: {key}")
+            return val.decode("utf-8") if isinstance(val, bytes) else val
+        await self._r.hincrby(stats_key, "misses", 1)
+        return None
+
+    async def set(self, key: str, agent_name: str, value: str, ttl: int) -> None:
+        await self._r.setex(key, ttl, value)
+
+    async def get_ttl_for_agent(self, agent_name: str) -> int:
+        val = await self._r.get(f"rm:cache_ttl:{agent_name}")
+        if val is not None:
+            return int(val)
+        return settings.DEFAULT_CACHE_TTL_SECONDS
+
+    async def set_ttl_for_agent(self, agent_name: str, ttl: int) -> None:
+        await self._r.set(f"rm:cache_ttl:{agent_name}", ttl)
+
+    async def clear_all(self) -> int:
+        keys = await self._r.keys(f"{CACHE_NS}:*")
+        if keys:
+            return await self._r.delete(*keys)
+        return 0
+
+    async def clear_agent(self, agent_name: str) -> int:
+        keys = await self._r.keys(f"{CACHE_NS}:{agent_name}:*")
+        if keys:
+            return await self._r.delete(*keys)
+        return 0
+
+    async def get_stats(self) -> dict:
+        keys = await self._r.keys(f"{CACHE_STATS_NS}:*")
+        stats = {}
+        for key in keys:
+            key_str = key.decode() if isinstance(key, bytes) else key
+            agent_name = key_str.split(":")[-1]
+            raw = await self._r.hgetall(key)
+            entry = {
+                (k.decode() if isinstance(k, bytes) else k): int(v)
+                for k, v in raw.items()
+            }
+            total = entry.get("hits", 0) + entry.get("misses", 0)
+            entry["hit_rate"] = round(entry.get("hits", 0) / total, 3) if total else 0.0
+            stats[agent_name] = entry
+        return stats
+
+
+class RequestLogger:
+    """Stores the last N requests per agent in Redis for analytics."""
+
+    def __init__(self, redis_client: aioredis.Redis):
+        self._r = redis_client
+
+    async def log(
+        self,
+        agent_name: str,
+        query: str,
+        cache_result: str,
+        latency_ms: float,
+        queued: bool = False,
+        error: bool = False,
+        method: str = "message/send",
+    ) -> None:
+        entry = json.dumps({
+            "ts": round(time.time(), 3),
+            "agent": agent_name,
+            "query": query[:300],  # cap length
+            "cache": cache_result,
+            "latency_ms": round(latency_ms, 1),
+            "queued": queued,
+            "error": error,
+            "method": method,
+        })
+        pipe = self._r.pipeline()
+        log_key = f"{REQ_LOG_NS}:{agent_name}"
+        pipe.lpush(log_key, entry)
+        pipe.ltrim(log_key, 0, REQ_LOG_MAX - 1)
+        await pipe.execute()
+
+    async def get_recent(self, agent_name: str, limit: int = 20) -> list:
+        raw = await self._r.lrange(f"{REQ_LOG_NS}:{agent_name}", 0, limit - 1)
+        return [json.loads(r) for r in raw]
+
+    async def get_all_agents(self) -> list[str]:
+        keys = await self._r.keys(f"{REQ_LOG_NS}:*")
+        return [
+            (k.decode() if isinstance(k, bytes) else k).split(":", 2)[-1]
+            for k in keys
+        ]
+
+    async def get_all_recent(self, limit: int = 50) -> list:
+        agents = await self.get_all_agents()
+        all_entries = []
+        for agent in agents:
+            entries = await self.get_recent(agent, limit=limit)
+            all_entries.extend(entries)
+        all_entries.sort(key=lambda e: e["ts"], reverse=True)
+        return all_entries[:limit]

--- a/agent-gateway/request-manager/src/config.py
+++ b/agent-gateway/request-manager/src/config.py
@@ -1,0 +1,30 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    REDIS_URL: str = "redis://redis:6379/0"
+
+    DEFAULT_RATE_LIMIT_RPM: int = 60
+    RATE_LIMIT_WINDOW_SECONDS: int = 60
+
+    QUEUE_MAX_DEPTH: int = 100
+    QUEUE_TIMEOUT_SECONDS: float = 30.0
+
+    DEFAULT_CACHE_TTL_SECONDS: int = 3600
+
+    UPSTREAM_CONNECT_TIMEOUT: float = 10.0
+    UPSTREAM_READ_TIMEOUT: float = 300.0
+
+    LOG_LEVEL: str = "INFO"
+
+    OTEL_EXPORTER_OTLP_ENDPOINT: str = "http://phoenix-observability:4317"
+    OTEL_SERVICE_NAME: str = "nasiko-request-manager"
+
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "case_sensitive": False,
+    }
+
+
+settings = Settings()

--- a/agent-gateway/request-manager/src/dashboard.py
+++ b/agent-gateway/request-manager/src/dashboard.py
@@ -1,0 +1,509 @@
+DASHBOARD_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Request Manager · Nasiko</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#09090B;--surface:#111113;--surface2:#18181B;--border:#27272A;--border2:#1C1C1F;
+  --text:#FAFAFA;--muted:#A1A1AA;--dim:#52525B;
+  --purple:#8B5CF6;--purple-bg:#2D1B69;
+  --green:#22C55E;--green-bg:#052E16;
+  --yellow:#EAB308;--yellow-bg:#1C1506;
+  --red:#EF4444;--red-bg:#1F0A0A;
+  --blue:#3B82F6;--blue-bg:#0D1F4A;
+  --r:8px;
+}
+html{font-size:14px}
+body{font-family:'Inter',-apple-system,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;line-height:1.5;-webkit-font-smoothing:antialiased}
+.layout{display:flex;min-height:100vh}
+
+/* sidebar */
+.sidebar{width:220px;background:var(--surface);border-right:1px solid var(--border);flex-shrink:0;display:flex;flex-direction:column}
+.logo{padding:18px 16px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px}
+.logo-icon{width:28px;height:28px;background:var(--purple);border-radius:7px;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;color:#fff;flex-shrink:0}
+.logo-name{font-size:14px;font-weight:600}
+.logo-sub{font-size:10px;color:var(--muted);margin-top:1px}
+.nav-section{padding:16px 12px 6px}
+.nav-label{font-size:10px;font-weight:600;color:var(--dim);text-transform:uppercase;letter-spacing:1px;padding:0 6px;margin-bottom:4px}
+.nav-item{display:flex;align-items:center;gap:9px;padding:7px 10px;border-radius:6px;cursor:pointer;font-size:13px;color:var(--muted);font-weight:450;margin-bottom:1px;user-select:none;transition:background .1s,color .1s}
+.nav-item:hover{background:var(--surface2);color:var(--text)}
+.nav-item.active{background:var(--purple-bg);color:var(--purple);font-weight:500}
+.nav-icon{width:16px;text-align:center;flex-shrink:0}
+.sidebar-footer{margin-top:auto;padding:14px 16px;border-top:1px solid var(--border);font-size:11px;color:var(--dim)}
+
+/* topbar */
+.main{flex:1;display:flex;flex-direction:column;min-width:0}
+.topbar{background:var(--surface);border-bottom:1px solid var(--border);padding:0 24px;height:52px;display:flex;align-items:center;justify-content:space-between;flex-shrink:0}
+.topbar-title{font-size:14px;font-weight:600}
+.topbar-right{display:flex;align-items:center;gap:12px}
+.badge{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:20px;font-size:11px;font-weight:500;border:1px solid var(--border);background:var(--surface2);color:var(--muted)}
+.badge.ok{border-color:#14532D;background:var(--green-bg);color:var(--green)}
+.badge.err{border-color:#450A0A;background:var(--red-bg);color:var(--red)}
+.bdot{width:6px;height:6px;border-radius:50%;background:currentColor}
+.ts{font-size:11px;color:var(--dim)}
+.content{flex:1;overflow-y:auto;padding:24px}
+
+/* views */
+.view{display:none}.view.active{display:block}
+
+/* cards */
+.card{background:var(--surface);border:1px solid var(--border);border-radius:var(--r);padding:18px 20px}
+.card+.card{margin-top:16px}
+.card-title{font-size:11px;font-weight:600;color:var(--dim);text-transform:uppercase;letter-spacing:.8px;margin-bottom:14px}
+.g4{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:16px}
+.g3{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:16px}
+.g2{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px}
+.kv{font-size:30px;font-weight:700;line-height:1.1;letter-spacing:-.5px}
+.ks{font-size:11px;color:var(--dim);margin-top:5px}
+
+/* colours */
+.cp{color:var(--purple)}.cg{color:var(--green)}.cy{color:var(--yellow)}.cr{color:var(--red)}.cb{color:var(--blue)}
+
+/* bar */
+.bar-t{background:var(--surface2);border-radius:4px;height:6px;overflow:hidden;margin-top:8px}
+.bar-f{height:100%;border-radius:4px;transition:width .5s}
+
+/* table */
+.tw{overflow-x:auto}
+table{width:100%;border-collapse:collapse;font-size:12.5px}
+th{text-align:left;font-size:10.5px;font-weight:600;color:var(--dim);text-transform:uppercase;letter-spacing:.6px;padding:7px 12px;border-bottom:1px solid var(--border);white-space:nowrap}
+td{padding:9px 12px;border-bottom:1px solid var(--border2)}
+tr:last-child td{border-bottom:none}
+tbody tr:hover td{background:var(--surface2)}
+
+/* tags */
+.tag{display:inline-flex;align-items:center;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:600}
+.t-hit{background:var(--green-bg);color:var(--green)}
+.t-miss{background:var(--blue-bg);color:var(--blue)}
+.t-rej{background:var(--red-bg);color:var(--red)}
+.t-custom{background:var(--purple-bg);color:var(--purple)}
+.t-def{background:var(--surface2);color:var(--muted)}
+
+/* buttons */
+.btn{display:inline-flex;align-items:center;gap:6px;padding:7px 14px;border-radius:6px;font-size:12px;font-weight:500;cursor:pointer;border:1px solid var(--border);background:var(--surface2);color:var(--muted);font-family:inherit;transition:background .12s,color .12s;white-space:nowrap}
+.btn:hover{background:var(--border);color:var(--text)}
+.btn.danger{border-color:#450A0A;background:var(--red-bg);color:var(--red)}
+.btn.danger:hover{background:#3b0909}
+.btn.primary{border-color:var(--purple-bg);background:var(--purple-bg);color:var(--purple)}
+.btn.primary:hover{background:#3b2080}
+.btn.sm{padding:3px 10px;font-size:11px}
+
+/* forms */
+.field{display:flex;flex-direction:column;gap:4px}
+.field label{font-size:12px;color:var(--muted)}
+input,select{background:var(--surface2);border:1px solid var(--border);border-radius:6px;color:var(--text);font-family:inherit;font-size:12.5px;padding:7px 10px;outline:none;width:100%}
+input:focus,select:focus{border-color:var(--purple)}
+input::placeholder{color:var(--dim)}
+.form-row{display:flex;align-items:flex-end;gap:10px;flex-wrap:wrap}
+.form-row .field{flex:1;min-width:150px}
+
+/* misc */
+.mono{font-family:'SFMono-Regular',Consolas,monospace}
+.trunc{max-width:260px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.lf{color:var(--green)}.lm{color:var(--yellow)}.ls{color:var(--red)}
+.empty{color:var(--dim);font-size:12px;padding:24px 0;text-align:center}
+.sh{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;flex-wrap:wrap;gap:8px}
+.sh-t{font-size:13px;font-weight:600}
+.sh-s{font-size:11px;color:var(--dim)}
+.divider{height:1px;background:var(--border2);margin:16px 0}
+.toast{position:fixed;bottom:24px;right:24px;background:var(--surface2);border:1px solid var(--border);border-radius:8px;padding:10px 18px;font-size:12.5px;color:var(--text);box-shadow:0 4px 20px #00000060;z-index:9999;transition:opacity .3s}
+::-webkit-scrollbar{width:6px;height:6px}::-webkit-scrollbar-track{background:transparent}::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
+</style>
+</head>
+<body>
+<div class="layout">
+
+<aside class="sidebar">
+  <div class="logo">
+    <div class="logo-icon">N</div>
+    <div><div class="logo-name">Nasiko</div><div class="logo-sub">Agent Platform</div></div>
+  </div>
+  <div class="nav-section">
+    <div class="nav-label">Observability</div>
+    <div class="nav-item active" data-view="overview"><span class="nav-icon">⬡</span>Overview</div>
+    <div class="nav-item" id="nav-phoenix"><span class="nav-icon">◈</span>Phoenix Traces</div>
+  </div>
+  <div class="nav-section">
+    <div class="nav-label">Management</div>
+    <div class="nav-item" data-view="cache"><span class="nav-icon">◫</span>Cache</div>
+    <div class="nav-item" data-view="ratelimits"><span class="nav-icon">◎</span>Rate Limits</div>
+    <div class="nav-item" data-view="requests"><span class="nav-icon">◌</span>Requests</div>
+  </div>
+  <div class="sidebar-footer" id="footer-ts">Auto-refreshes every 5s</div>
+</aside>
+
+<div class="main">
+  <div class="topbar">
+    <span class="topbar-title" id="page-title">Overview</span>
+    <div class="topbar-right">
+      <span class="ts" id="refresh-ts"></span>
+      <span class="badge" id="hbadge"><span class="bdot"></span><span id="htext">connecting</span></span>
+    </div>
+  </div>
+
+  <div class="content">
+
+    <!-- OVERVIEW -->
+    <div class="view active" id="view-overview">
+      <div class="g4">
+        <div class="card"><div class="card-title">Total Requests</div><div class="kv cb" id="s-total">—</div></div>
+        <div class="card"><div class="card-title">Cache Hits</div><div class="kv cg" id="s-hits">—</div><div class="ks" id="s-hr">—</div></div>
+        <div class="card"><div class="card-title">Cache Misses</div><div class="kv cy" id="s-miss">—</div></div>
+        <div class="card"><div class="card-title">Errors</div><div class="kv cr" id="s-err">—</div></div>
+      </div>
+      <div class="g3">
+        <div class="card"><div class="card-title">Rate Limited</div><div class="kv cy" id="s-lim">—</div><div class="ks">held &amp; queued</div></div>
+        <div class="card"><div class="card-title">Queued &amp; Served</div><div class="kv cp" id="s-q">—</div></div>
+        <div class="card"><div class="card-title">Rejected</div><div class="kv cr" id="s-rej">—</div><div class="ks">queue full or timeout</div></div>
+      </div>
+      <div class="g2">
+        <div class="card">
+          <div class="sh"><span class="sh-t">Cache per agent</span></div>
+          <div class="tw" id="ov-cache"><div class="empty">No data yet</div></div>
+        </div>
+        <div class="card">
+          <div class="sh"><span class="sh-t">Rate limit events</span></div>
+          <div id="ov-rl"><div class="empty">No traffic yet</div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CACHE -->
+    <div class="view" id="view-cache">
+      <div class="card">
+        <div class="sh">
+          <span class="sh-t">Cache stats</span>
+          <button class="btn danger" id="btn-clear-all">Clear all cache</button>
+        </div>
+        <div class="tw" id="cache-tbl"><div class="empty">No data yet</div></div>
+      </div>
+      <div class="card">
+        <div class="sh"><span class="sh-t">Clear agent cache</span></div>
+        <div class="form-row">
+          <div class="field" style="max-width:300px">
+            <label>Agent container name</label>
+            <input id="cache-agent-in" placeholder="e.g. agent-a2a-translator">
+          </div>
+          <button class="btn danger" id="btn-clear-agent">Clear</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- RATE LIMITS -->
+    <div class="view" id="view-ratelimits">
+      <div class="card">
+        <div class="sh"><span class="sh-t">Set rate limit</span></div>
+        <div class="form-row" style="margin-bottom:20px">
+          <div class="field">
+            <label>Agent name</label>
+            <input id="rl-agent" placeholder="e.g. agent-a2a-translator">
+          </div>
+          <div class="field" style="max-width:150px">
+            <label>Requests / minute</label>
+            <input id="rl-rpm" type="number" min="1" placeholder="60">
+          </div>
+          <button class="btn primary" id="btn-set-rl">Apply limit</button>
+        </div>
+        <div class="divider"></div>
+        <div class="sh" style="margin-top:4px"><span class="sh-t">Reset to default</span></div>
+        <div class="form-row">
+          <div class="field" style="max-width:300px">
+            <label>Agent name</label>
+            <input id="rl-reset" placeholder="e.g. agent-a2a-translator">
+          </div>
+          <button class="btn danger" id="btn-reset-rl">Reset</button>
+        </div>
+      </div>
+      <div class="card">
+        <div class="sh"><span class="sh-t">Current limits</span></div>
+        <div class="tw" id="rl-tbl"><div class="empty">No data yet</div></div>
+      </div>
+    </div>
+
+    <!-- REQUESTS -->
+    <div class="view" id="view-requests">
+      <div class="card">
+        <div class="sh">
+          <span class="sh-t">Recent requests</span>
+          <div style="display:flex;align-items:center;gap:10px">
+            <label style="font-size:12px;color:var(--muted);white-space:nowrap">Filter agent</label>
+            <select id="req-filter" style="width:220px;padding:5px 10px"></select>
+            <span class="sh-s" id="req-count"></span>
+          </div>
+        </div>
+        <div class="tw" id="req-tbl"><div class="empty">No requests yet</div></div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</div>
+
+<script>
+var _allReqs = [];
+var _limitsData = {};
+
+/* ── Navigation ── */
+var TITLES = {overview:'Overview', cache:'Cache Management', ratelimits:'Rate Limits', requests:'Recent Requests'};
+document.querySelectorAll('.nav-item[data-view]').forEach(function(el) {
+  el.addEventListener('click', function() {
+    var view = this.dataset.view;
+    document.querySelectorAll('.view').forEach(function(v){v.classList.remove('active')});
+    document.getElementById('view-'+view).classList.add('active');
+    document.querySelectorAll('.nav-item').forEach(function(n){n.classList.remove('active')});
+    this.classList.add('active');
+    document.getElementById('page-title').textContent = TITLES[view] || view;
+  });
+});
+document.getElementById('nav-phoenix').addEventListener('click', function() {
+  window.open('http://localhost:6006','_blank');
+});
+
+/* ── Toast ── */
+function toast(msg, col) {
+  var t = document.createElement('div');
+  t.className = 'toast';
+  if (col) t.style.borderColor = col;
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(function(){ t.style.opacity='0'; setTimeout(function(){t.remove()},300); }, 2500);
+}
+
+/* ── Helpers ── */
+function fmt(n) { return (n == null) ? '0' : Number(n).toLocaleString(); }
+function age(ts) {
+  var d = Math.floor(Date.now()/1000 - ts);
+  if (d < 5)    return 'just now';
+  if (d < 60)   return d+'s ago';
+  if (d < 3600) return Math.floor(d/60)+'m ago';
+  return Math.floor(d/3600)+'h ago';
+}
+function latCls(ms) { return ms < 10 ? 'lf' : ms < 500 ? 'lm' : 'ls'; }
+function tagHtml(c) {
+  if (c === 'HIT')  return '<span class="tag t-hit">HIT</span>';
+  if (c === 'MISS') return '<span class="tag t-miss">MISS</span>';
+  return '<span class="tag t-rej">'+c+'</span>';
+}
+function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+/* ── Cache actions ── */
+document.getElementById('btn-clear-all').addEventListener('click', function() {
+  if (!confirm('Clear ALL cached responses across all agents?')) return;
+  fetch('/manage/cache', {method:'DELETE'}).then(function(r){return r.json()}).then(function(d){
+    toast('Cleared '+( d.cleared_keys||0)+' keys', 'var(--green)');
+    fetchAll();
+  }).catch(function(e){ toast('Error: '+e.message, 'var(--red)'); });
+});
+
+document.getElementById('btn-clear-agent').addEventListener('click', function() {
+  var agent = document.getElementById('cache-agent-in').value.trim();
+  if (!agent) { toast('Enter an agent name', 'var(--yellow)'); return; }
+  fetch('/manage/cache/'+encodeURIComponent(agent), {method:'DELETE'}).then(function(r){return r.json()}).then(function(d){
+    toast('Cleared '+(d.cleared_keys||0)+' keys for '+agent, 'var(--green)');
+    document.getElementById('cache-agent-in').value = '';
+    fetchAll();
+  }).catch(function(e){ toast('Error: '+e.message, 'var(--red)'); });
+});
+
+/* ── Rate limit actions ── */
+document.getElementById('btn-set-rl').addEventListener('click', function() {
+  var agent = document.getElementById('rl-agent').value.trim();
+  var rpm   = parseInt(document.getElementById('rl-rpm').value);
+  if (!agent) { toast('Enter an agent name', 'var(--yellow)'); return; }
+  if (!rpm || rpm < 1) { toast('Enter a valid requests/minute value', 'var(--yellow)'); return; }
+  fetch('/manage/rate-limits/'+encodeURIComponent(agent), {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({requests_per_minute: rpm})
+  }).then(function(r){
+    if (!r.ok) throw new Error('Server error '+r.status);
+    toast('Set '+agent+' to '+rpm+' req/min', 'var(--green)');
+    document.getElementById('rl-agent').value = '';
+    document.getElementById('rl-rpm').value   = '';
+    fetchAll();
+  }).catch(function(e){ toast('Error: '+e.message, 'var(--red)'); });
+});
+
+document.getElementById('btn-reset-rl').addEventListener('click', function() {
+  var agent = document.getElementById('rl-reset').value.trim();
+  if (!agent) { toast('Enter an agent name', 'var(--yellow)'); return; }
+  fetch('/manage/rate-limits/'+encodeURIComponent(agent), {method:'DELETE'}).then(function(){
+    toast('Reset '+agent+' to default', 'var(--green)');
+    document.getElementById('rl-reset').value = '';
+    fetchAll();
+  }).catch(function(e){ toast('Error: '+e.message, 'var(--red)'); });
+});
+
+/* Table-level delegated edit/reset for rate limits */
+document.getElementById('rl-tbl').addEventListener('click', function(e) {
+  var btn   = e.target.closest('button');
+  if (!btn) return;
+  var agent = btn.dataset.agent;
+  if (!agent) return;
+  if (btn.dataset.action === 'edit') {
+    document.getElementById('rl-agent').value = agent;
+    document.getElementById('rl-rpm').focus();
+  } else if (btn.dataset.action === 'reset') {
+    fetch('/manage/rate-limits/'+encodeURIComponent(agent), {method:'DELETE'}).then(function(){
+      toast('Reset '+agent+' to default', 'var(--green)');
+      fetchAll();
+    });
+  }
+});
+
+/* Table-level delegated clear for cache */
+document.getElementById('cache-tbl').addEventListener('click', function(e) {
+  var btn = e.target.closest('button');
+  if (!btn || !btn.dataset.agent) return;
+  var agent = btn.dataset.agent;
+  fetch('/manage/cache/'+encodeURIComponent(agent), {method:'DELETE'}).then(function(r){return r.json()}).then(function(d){
+    toast('Cleared '+(d.cleared_keys||0)+' keys for '+agent, 'var(--green)');
+    fetchAll();
+  });
+});
+
+/* ── Requests filter ── */
+document.getElementById('req-filter').addEventListener('change', renderRequests);
+function renderRequests() {
+  var filter = document.getElementById('req-filter').value;
+  var rows = filter ? _allReqs.filter(function(r){return r.agent === filter}) : _allReqs;
+  document.getElementById('req-count').textContent = rows.length + ' requests';
+  if (!rows.length) { document.getElementById('req-tbl').innerHTML = '<div class="empty">No requests</div>'; return; }
+  var h = '<table><thead><tr><th>Time</th><th>Agent</th><th>Query</th><th>Cache</th><th>Latency</th><th>Flags</th></tr></thead><tbody>';
+  rows.forEach(function(r) {
+    var flags = [];
+    if (r.queued) flags.push('<span style="color:var(--purple);font-size:11px">queued</span>');
+    if (r.error)  flags.push('<span style="color:var(--red);font-size:11px">error</span>');
+    h += '<tr><td class="mono" style="font-size:11px;color:var(--dim);white-space:nowrap">'+age(r.ts)+'</td>'+
+         '<td><span class="mono cp" style="font-size:11.5px">'+esc(r.agent)+'</span></td>'+
+         '<td><div class="trunc" title="'+esc(r.query||'')+'">'+esc(r.query||'—')+'</div></td>'+
+         '<td>'+tagHtml(r.cache)+'</td>'+
+         '<td><span class="mono '+latCls(r.latency_ms)+'">'+r.latency_ms+'ms</span></td>'+
+         '<td>'+(flags.join(' ') || '<span style="color:var(--dim)">—</span>')+'</td></tr>';
+  });
+  h += '</tbody></table>';
+  document.getElementById('req-tbl').innerHTML = h;
+}
+
+/* ── Main fetch loop ── */
+function fetchAll() {
+  Promise.all([
+    fetch('/manage/stats').then(function(r){return r.json()}).catch(function(){return {}}),
+    fetch('/manage/cache/stats').then(function(r){return r.json()}).catch(function(){return {}}),
+    fetch('/manage/rate-limits').then(function(r){return r.json()}).catch(function(){return {}}),
+    fetch('/manage/requests?limit=50').then(function(r){return r.json()}).catch(function(){return []}),
+    fetch('/manage/health').then(function(r){return r.json()}).catch(function(){return {}})
+  ]).then(function(results) {
+    var statsR = results[0], cacheR = results[1], limitsR = results[2], reqsR = results[3], healthR = results[4];
+
+    /* health */
+    var ok = healthR.status === 'healthy';
+    document.getElementById('hbadge').className = 'badge '+(ok?'ok':'err');
+    document.getElementById('htext').textContent = ok ? 'healthy' : 'degraded';
+    var ts = new Date().toLocaleTimeString();
+    document.getElementById('refresh-ts').textContent = 'Updated '+ts;
+    document.getElementById('footer-ts').textContent  = 'Last updated '+ts;
+
+    /* KPIs */
+    var g = statsR.global || {};
+    document.getElementById('s-total').textContent = fmt(g.total_requests);
+    document.getElementById('s-hits').textContent  = fmt(g.cache_hits);
+    document.getElementById('s-miss').textContent  = fmt(g.cache_misses);
+    document.getElementById('s-err').textContent   = fmt(g.errors);
+    document.getElementById('s-lim').textContent   = fmt(g.rate_limited);
+    document.getElementById('s-q').textContent     = fmt(g.queued);
+    document.getElementById('s-rej').textContent   = fmt((g.rejected_queue_full||0)+(g.rejected_timeout||0));
+    var tot = (g.cache_hits||0)+(g.cache_misses||0);
+    document.getElementById('s-hr').textContent = tot ? ((g.cache_hits||0)/tot*100).toFixed(1)+'% hit rate' : '—';
+
+    /* cache tables */
+    var ce = Object.entries(cacheR);
+    function buildCacheTable(withActions) {
+      if (!ce.length) return '<div class="empty">No cache data yet</div>';
+      var h = '<table><thead><tr><th>Agent</th><th>Hits</th><th>Misses</th><th>Hit rate</th><th style="width:100px"></th>';
+      if (withActions) h += '<th>Action</th>';
+      h += '</tr></thead><tbody>';
+      ce.forEach(function(entry) {
+        var agent = entry[0], d = entry[1];
+        var pct = Math.round((d.hit_rate||0)*100);
+        var col = pct>60?'var(--green)':pct>30?'var(--yellow)':'var(--red)';
+        h += '<tr><td><span class="mono cp" style="font-size:11.5px">'+esc(agent)+'</span></td>'+
+             '<td class="cg">'+fmt(d.hits)+'</td><td class="cy">'+fmt(d.misses)+'</td><td>'+pct+'%</td>'+
+             '<td><div class="bar-t"><div class="bar-f" style="width:'+pct+'%;background:'+col+'"></div></div></td>';
+        if (withActions) h += '<td><button class="btn danger sm" data-agent="'+esc(agent)+'">Clear</button></td>';
+        h += '</tr>';
+      });
+      return h+'</tbody></table>';
+    }
+    document.getElementById('ov-cache').innerHTML    = buildCacheTable(false);
+    document.getElementById('cache-tbl').innerHTML   = buildCacheTable(true);
+
+    /* ov rate-limit summary */
+    var def = limitsR.default || {};
+    var overrides = limitsR.per_agent_overrides || {};
+    var rlEv = (statsR.rate_limit_events) || {};
+    var agents = Object.keys(Object.assign({}, overrides, rlEv));
+    var ovHtml = '<div style="display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border2)"><span style="color:var(--muted);font-size:12px">Default</span><span class="mono" style="font-size:11px;color:var(--muted)">'+(def.requests_per_minute||60)+' req/min</span></div>';
+    agents.forEach(function(a) {
+      var ev = rlEv[a]||{};
+      var rpm = (overrides[a]&&overrides[a].requests_per_minute) || def.requests_per_minute || 60;
+      ovHtml += '<div style="padding:10px 0;border-bottom:1px solid var(--border2)">'+
+        '<div style="display:flex;justify-content:space-between;align-items:center">'+
+        '<span class="mono cp" style="font-size:12px">'+esc(a)+'</span>'+
+        '<span class="mono" style="font-size:11px;color:var(--muted)">'+rpm+' req/min'+(overrides[a]?' <span style="color:var(--purple);font-size:10px">custom</span>':'')+'</span></div>'+
+        '<div style="font-size:11px;color:var(--dim);margin-top:3px">✓ '+fmt(ev.allowed)+' allowed &nbsp;·&nbsp; ⏸ '+fmt(ev.limited)+' limited &nbsp;·&nbsp; ⏳ '+fmt(ev.queued)+' queued</div>'+
+        '</div>';
+    });
+    if (!agents.length) ovHtml += '<div class="empty">No agent traffic yet</div>';
+    document.getElementById('ov-rl').innerHTML = ovHtml;
+
+    /* rate limits table */
+    var rlHtml = '<table><thead><tr><th>Agent</th><th>RPM</th><th>Type</th><th>Allowed</th><th>Limited</th><th>Queued</th><th>Actions</th></tr></thead><tbody>';
+    rlHtml += '<tr><td style="color:var(--dim)">Default</td><td>'+(def.requests_per_minute||60)+'</td><td><span class="tag t-def">global</span></td><td colspan="4" style="color:var(--dim)">—</td></tr>';
+    agents.forEach(function(a) {
+      var ev = rlEv[a]||{};
+      var isCustom = !!overrides[a];
+      var rpm = (isCustom && overrides[a].requests_per_minute) || def.requests_per_minute || 60;
+      rlHtml += '<tr>'+
+        '<td><span class="mono cp" style="font-size:11.5px">'+esc(a)+'</span></td>'+
+        '<td>'+rpm+'</td>'+
+        '<td>'+(isCustom?'<span class="tag t-custom">custom</span>':'<span class="tag t-def">default</span>')+'</td>'+
+        '<td class="cg">'+fmt(ev.allowed)+'</td>'+
+        '<td class="cy">'+fmt(ev.limited)+'</td>'+
+        '<td class="cp">'+fmt(ev.queued)+'</td>'+
+        '<td style="display:flex;gap:6px;flex-wrap:wrap">'+
+          '<button class="btn sm" data-agent="'+esc(a)+'" data-action="edit">Edit</button>'+
+          (isCustom?'<button class="btn danger sm" data-agent="'+esc(a)+'" data-action="reset">Reset</button>':'') +
+        '</td></tr>';
+    });
+    if (!agents.length) rlHtml += '<tr><td colspan="7" class="empty" style="text-align:center">No agent rate limit data yet</td></tr>';
+    rlHtml += '</tbody></table>';
+    document.getElementById('rl-tbl').innerHTML = rlHtml;
+
+    /* requests */
+    _allReqs = Array.isArray(reqsR) ? reqsR : [];
+    var names = [];
+    _allReqs.forEach(function(r){ if (names.indexOf(r.agent)<0) names.push(r.agent); });
+    var sel = document.getElementById('req-filter');
+    var prev = sel.value;
+    sel.innerHTML = '<option value="">All agents</option>';
+    names.forEach(function(n){
+      var opt = document.createElement('option');
+      opt.value = n; opt.textContent = n;
+      if (n === prev) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    renderRequests();
+  });
+}
+
+fetchAll();
+setInterval(fetchAll, 5000);
+</script>
+</body>
+</html>"""

--- a/agent-gateway/request-manager/src/main.py
+++ b/agent-gateway/request-manager/src/main.py
@@ -1,0 +1,380 @@
+import asyncio
+import json
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import Dict, Optional
+
+import httpx
+import redis.asyncio as aioredis
+from fastapi import FastAPI, HTTPException, Request, Response
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pythonjsonlogger import jsonlogger
+
+from src.cache import CacheManager, RequestLogger, build_cache_key, deduplicate_history, extract_query_text
+from src.config import settings
+from src.dashboard import DASHBOARD_HTML
+from src.rate_limiter import RateLimiterAndQueue
+
+_handler = logging.StreamHandler()
+_handler.setFormatter(jsonlogger.JsonFormatter())
+logging.basicConfig(level=settings.LOG_LEVEL, handlers=[_handler])
+logger = logging.getLogger(__name__)
+
+_redis: Optional[aioredis.Redis] = None
+_cache: Optional[CacheManager] = None
+_limiter: Optional[RateLimiterAndQueue] = None
+_req_log: Optional[RequestLogger] = None
+
+_stats: Dict[str, int] = {
+    "total_requests": 0,
+    "cache_hits": 0,
+    "cache_misses": 0,
+    "rate_limited": 0,
+    "queued": 0,
+    "rejected_queue_full": 0,
+    "rejected_timeout": 0,
+    "errors": 0,
+}
+
+# ── OpenTelemetry setup ─────────────────────────────────────────────────────
+
+def _setup_tracing():
+    resource = Resource.create({"service.name": settings.OTEL_SERVICE_NAME})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=settings.OTEL_EXPORTER_OTLP_ENDPOINT, insecure=True)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+_setup_tracing()
+tracer = trace.get_tracer("request-manager")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _redis, _cache, _limiter, _req_log
+    _redis = aioredis.from_url(settings.REDIS_URL, decode_responses=False)
+    _cache = CacheManager(_redis)
+    _limiter = RateLimiterAndQueue(_redis)
+    _req_log = RequestLogger(_redis)
+    logger.info("request-manager started", extra={"redis_url": settings.REDIS_URL})
+    yield
+    await _redis.aclose()
+
+
+app = FastAPI(
+    title="Nasiko Request Manager",
+    version="1.0.0",
+    description="Caching, rate limiting, and queueing layer between Kong and agent containers",
+    lifespan=lifespan,
+)
+
+
+# ── Upstream helpers ────────────────────────────────────────────────────────
+
+async def _proxy_upstream(upstream_url: str, body: dict, headers: dict) -> dict:
+    timeout = httpx.Timeout(
+        connect=settings.UPSTREAM_CONNECT_TIMEOUT,
+        read=settings.UPSTREAM_READ_TIMEOUT,
+        write=30.0,
+        pool=5.0,
+    )
+    with tracer.start_as_current_span("upstream.call") as span:
+        span.set_attribute("upstream.url", upstream_url)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(upstream_url, json=body, headers=headers)
+            span.set_attribute("upstream.status_code", resp.status_code)
+            resp.raise_for_status()
+            return resp.json()
+
+
+def _safe_headers(request: Request) -> dict:
+    hop_by_hop = {
+        "host", "connection", "keep-alive", "transfer-encoding",
+        "te", "trailer", "upgrade", "proxy-authenticate",
+        "proxy-authorization", "content-length",
+    }
+    return {k: v for k, v in request.headers.items() if k.lower() not in hop_by_hop}
+
+
+# ── Main proxy endpoint ─────────────────────────────────────────────────────
+
+@app.api_route(
+    "/proxy/{agent_host}/{port}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+)
+async def proxy_root(request: Request, agent_host: str, port: int) -> Response:
+    return await proxy(request, agent_host, port, "")
+
+
+@app.api_route(
+    "/proxy/{agent_host}/{port}/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+)
+async def proxy(request: Request, agent_host: str, port: int, path: str) -> Response:
+    _stats["total_requests"] += 1
+    t_start = time.monotonic()
+    upstream_url = f"http://{agent_host}:{port}/{path}"
+    headers = _safe_headers(request)
+
+    with tracer.start_as_current_span("request-manager.proxy") as span:
+        span.set_attribute("agent.name", agent_host)
+        span.set_attribute("upstream.url", upstream_url)
+        span.set_attribute("http.method", request.method)
+
+        # File uploads: bypass cache and rate limit, proxy raw bytes
+        content_type = request.headers.get("content-type", "")
+        if "multipart/form-data" in content_type:
+            raw = await request.body()
+            timeout = httpx.Timeout(connect=settings.UPSTREAM_CONNECT_TIMEOUT,
+                                    read=settings.UPSTREAM_READ_TIMEOUT, write=30.0, pool=5.0)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.request(
+                    method=request.method, url=upstream_url, content=raw, headers=headers
+                )
+            span.set_attribute("request.type", "multipart_bypass")
+            return Response(content=resp.content, status_code=resp.status_code,
+                            headers=dict(resp.headers),
+                            media_type=resp.headers.get("content-type", "application/json"))
+
+        # Parse JSON body; proxy raw if unparseable
+        try:
+            body: dict = await request.json()
+        except Exception:
+            raw = await request.body()
+            span.set_attribute("request.type", "raw_bypass")
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(
+                    method=request.method, url=upstream_url, content=raw, headers=headers
+                )
+            return Response(content=resp.content, status_code=resp.status_code,
+                            media_type=resp.headers.get("content-type", "application/json"))
+
+        agent_name = agent_host
+        body = deduplicate_history(body)
+        query = extract_query_text(body)
+        method = body.get("method", "unknown")
+        span.set_attribute("query.text", query[:200])
+        span.set_attribute("jsonrpc.method", method)
+
+        # Cache check
+        cache_key = build_cache_key(agent_name, body)
+        cached = await _cache.get(cache_key, agent_name)
+        if cached is not None:
+            _stats["cache_hits"] += 1
+            latency_ms = (time.monotonic() - t_start) * 1000
+            span.set_attribute("cache.result", "HIT")
+            span.set_attribute("latency_ms", round(latency_ms, 1))
+            await _req_log.log(agent_name, query, "HIT", latency_ms, method=method)
+            return Response(content=cached, status_code=200,
+                            media_type="application/json",
+                            headers={"X-Cache": "HIT"})
+        _stats["cache_misses"] += 1
+        span.set_attribute("cache.result", "MISS")
+
+        # Rate limit check
+        allowed = await _limiter.check(agent_name)
+        span.set_attribute("rate_limit.allowed", allowed)
+
+        if allowed:
+            try:
+                data = await _proxy_upstream(upstream_url, body, headers)
+            except httpx.HTTPStatusError as exc:
+                _stats["errors"] += 1
+                latency_ms = (time.monotonic() - t_start) * 1000
+                span.set_attribute("error", True)
+                span.set_attribute("error.status_code", exc.response.status_code)
+                await _req_log.log(agent_name, query, "MISS", latency_ms, error=True, method=method)
+                raise HTTPException(status_code=exc.response.status_code, detail=exc.response.text)
+            except Exception as exc:
+                _stats["errors"] += 1
+                latency_ms = (time.monotonic() - t_start) * 1000
+                span.set_attribute("error", True)
+                span.set_attribute("error.message", str(exc))
+                await _req_log.log(agent_name, query, "MISS", latency_ms, error=True, method=method)
+                logger.error("upstream error", extra={"agent": agent_name, "error": str(exc)})
+                raise HTTPException(status_code=502, detail="Bad Gateway")
+
+            ttl = await _cache.get_ttl_for_agent(agent_name)
+            response_str = json.dumps(data)
+            await _cache.set(cache_key, agent_name, response_str, ttl)
+            latency_ms = (time.monotonic() - t_start) * 1000
+            span.set_attribute("cache.stored", True)
+            span.set_attribute("cache.ttl", ttl)
+            span.set_attribute("latency_ms", round(latency_ms, 1))
+            await _req_log.log(agent_name, query, "MISS", latency_ms, method=method)
+            return Response(content=response_str, status_code=200,
+                            media_type="application/json",
+                            headers={"X-Cache": "MISS"})
+
+        # Rate limit exceeded — enqueue
+        _stats["rate_limited"] += 1
+        span.set_attribute("queued", True)
+        logger.info("rate limited, queueing", extra={"agent": agent_name})
+
+        try:
+            data = await _limiter.enqueue(
+                agent_name=agent_name,
+                upstream_url=upstream_url,
+                body=body,
+                headers=headers,
+                proxy_fn=_proxy_upstream,
+            )
+            _stats["queued"] += 1
+            ttl = await _cache.get_ttl_for_agent(agent_name)
+            response_str = json.dumps(data)
+            await _cache.set(cache_key, agent_name, response_str, ttl)
+            latency_ms = (time.monotonic() - t_start) * 1000
+            span.set_attribute("latency_ms", round(latency_ms, 1))
+            await _req_log.log(agent_name, query, "MISS", latency_ms, queued=True, method=method)
+            return Response(content=response_str, status_code=200,
+                            media_type="application/json",
+                            headers={"X-Cache": "MISS", "X-Queued": "true"})
+
+        except asyncio.QueueFull:
+            _stats["rejected_queue_full"] += 1
+            latency_ms = (time.monotonic() - t_start) * 1000
+            span.set_attribute("error", True)
+            span.set_attribute("error.type", "queue_full")
+            await _req_log.log(agent_name, query, "REJECTED", latency_ms, error=True, method=method)
+            raise HTTPException(status_code=429, detail={
+                "error": "rate_limit_exceeded",
+                "message": f"Agent '{agent_name}' queue is full ({settings.QUEUE_MAX_DEPTH} max). Retry later.",
+            })
+        except asyncio.TimeoutError:
+            _stats["rejected_timeout"] += 1
+            latency_ms = (time.monotonic() - t_start) * 1000
+            span.set_attribute("error", True)
+            span.set_attribute("error.type", "queue_timeout")
+            await _req_log.log(agent_name, query, "REJECTED", latency_ms, error=True, method=method)
+            raise HTTPException(status_code=429, detail={
+                "error": "queue_timeout",
+                "message": f"Request for '{agent_name}' timed out after {settings.QUEUE_TIMEOUT_SECONDS}s in queue.",
+            })
+        except Exception as exc:
+            _stats["errors"] += 1
+            latency_ms = (time.monotonic() - t_start) * 1000
+            span.set_attribute("error", True)
+            span.set_attribute("error.message", str(exc))
+            await _req_log.log(agent_name, query, "MISS", latency_ms, error=True, method=method)
+            logger.error("queued proxy error", extra={"agent": agent_name, "error": str(exc)})
+            raise HTTPException(status_code=502, detail="Bad Gateway")
+
+
+# ── Monitoring endpoints ────────────────────────────────────────────────────
+
+@app.get("/manage/dashboard", response_class=Response)
+async def dashboard():
+    return Response(content=DASHBOARD_HTML, media_type="text/html")
+
+
+@app.get("/manage/health")
+async def health():
+    try:
+        await _redis.ping()
+        redis_ok = True
+    except Exception:
+        redis_ok = False
+    return {
+        "status": "healthy" if redis_ok else "degraded",
+        "redis": "connected" if redis_ok else "disconnected",
+        "timestamp": time.time(),
+    }
+
+
+@app.get("/manage/stats")
+async def stats():
+    # Derive totals from Redis so they survive restarts
+    cache_data = await _cache.get_stats()
+    total_hits   = sum(v.get("hits",   0) for v in cache_data.values())
+    total_misses = sum(v.get("misses", 0) for v in cache_data.values())
+
+    rl_events = await _limiter.rate_limit_stats()
+    total_limited = sum(v.get("limited", 0) for v in rl_events.values())
+    total_queued  = sum(v.get("queued",  0) for v in rl_events.values())
+
+    global_stats = {
+        "total_requests":      total_hits + total_misses,
+        "cache_hits":          total_hits,
+        "cache_misses":        total_misses,
+        "rate_limited":        total_limited,
+        "queued":              total_queued,
+        "rejected_queue_full": _stats["rejected_queue_full"],
+        "rejected_timeout":    _stats["rejected_timeout"],
+        "errors":              _stats["errors"],
+    }
+    return {
+        "global": global_stats,
+        "rate_limit_events": rl_events,
+    }
+
+
+@app.get("/manage/cache/stats")
+async def cache_stats():
+    return await _cache.get_stats()
+
+
+@app.get("/manage/requests")
+async def requests_all(limit: int = 50):
+    """Recent requests across all agents — newest first."""
+    return await _req_log.get_all_recent(limit=limit)
+
+
+@app.get("/manage/requests/{agent_name}")
+async def requests_agent(agent_name: str, limit: int = 20):
+    """Recent requests for a specific agent — newest first."""
+    entries = await _req_log.get_recent(agent_name, limit=limit)
+    hits = sum(1 for e in entries if e["cache"] == "HIT")
+    total = len(entries)
+    return {
+        "agent": agent_name,
+        "hit_rate": round(hits / total, 3) if total else 0.0,
+        "requests": entries,
+    }
+
+
+@app.delete("/manage/cache")
+async def cache_clear_all():
+    count = await _cache.clear_all()
+    return {"cleared_keys": count}
+
+
+@app.delete("/manage/cache/{agent_name}")
+async def cache_clear_agent(agent_name: str):
+    count = await _cache.clear_agent(agent_name)
+    return {"agent": agent_name, "cleared_keys": count}
+
+
+@app.get("/manage/rate-limits")
+async def rate_limits_list():
+    return {
+        "default": {
+            "requests_per_minute": settings.DEFAULT_RATE_LIMIT_RPM,
+            "window_seconds": settings.RATE_LIMIT_WINDOW_SECONDS,
+        },
+        "per_agent_overrides": await _limiter.get_all_limits(),
+    }
+
+
+@app.post("/manage/rate-limits/{agent_name}")
+async def rate_limit_set(agent_name: str, body: dict):
+    rpm = body.get("requests_per_minute")
+    if not isinstance(rpm, int) or rpm <= 0:
+        raise HTTPException(status_code=422, detail="requests_per_minute must be a positive integer")
+    await _limiter.set_limit(agent_name, rpm)
+    return {"agent": agent_name, "requests_per_minute": rpm}
+
+
+@app.delete("/manage/rate-limits/{agent_name}")
+async def rate_limit_reset(agent_name: str):
+    await _limiter.reset_limit(agent_name)
+    return {"agent": agent_name, "reset_to_default": settings.DEFAULT_RATE_LIMIT_RPM}
+
+
+@app.get("/manage/queue/stats")
+async def queue_stats():
+    return _limiter.queue_stats()

--- a/agent-gateway/request-manager/src/rate_limiter.py
+++ b/agent-gateway/request-manager/src/rate_limiter.py
@@ -1,0 +1,232 @@
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import redis.asyncio as aioredis
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+RL_NS = "rm:rl"
+RL_CFG_NS = "rm:rl_cfg"
+RL_STATS_NS = "rm:rl_stats"
+
+# Atomic sliding window Lua script.
+# Returns 1 if the request is allowed, 0 if rate limit exceeded.
+_SLIDING_WINDOW_LUA = """
+local key    = KEYS[1]
+local now    = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit  = tonumber(ARGV[3])
+local req_id = ARGV[4]
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, req_id)
+    redis.call('EXPIRE', key, window + 10)
+    return 1
+else
+    return 0
+end
+"""
+
+
+@dataclass
+class _QueuedRequest:
+    future: asyncio.Future
+    upstream_url: str
+    body: dict
+    headers: dict
+    enqueued_at: float = field(default_factory=time.monotonic)
+
+
+class RateLimiterAndQueue:
+    def __init__(self, redis_client: aioredis.Redis):
+        self._r = redis_client
+        self._lua_sha: Optional[str] = None
+        self._queues: Dict[str, asyncio.Queue] = {}
+        self._drain_tasks: Dict[str, asyncio.Task] = {}
+
+    # ── Lua script management ───────────────────────────────────────────────
+
+    async def _get_lua_sha(self) -> str:
+        if self._lua_sha is None:
+            self._lua_sha = await self._r.script_load(_SLIDING_WINDOW_LUA)
+        return self._lua_sha
+
+    # ── Per-agent limit config ──────────────────────────────────────────────
+
+    async def get_limit(self, agent_name: str) -> Tuple[int, int]:
+        """Return (rpm, window_seconds) — custom if set, else global default."""
+        val = await self._r.hgetall(f"{RL_CFG_NS}:{agent_name}")
+        if val:
+            rpm = int(val.get(b"rpm", settings.DEFAULT_RATE_LIMIT_RPM))
+            window = int(val.get(b"window", settings.RATE_LIMIT_WINDOW_SECONDS))
+            return rpm, window
+        return settings.DEFAULT_RATE_LIMIT_RPM, settings.RATE_LIMIT_WINDOW_SECONDS
+
+    async def set_limit(self, agent_name: str, rpm: int) -> None:
+        await self._r.hset(
+            f"{RL_CFG_NS}:{agent_name}",
+            mapping={"rpm": rpm, "window": settings.RATE_LIMIT_WINDOW_SECONDS},
+        )
+
+    async def reset_limit(self, agent_name: str) -> None:
+        await self._r.delete(f"{RL_CFG_NS}:{agent_name}")
+
+    async def get_all_limits(self) -> dict:
+        keys = await self._r.keys(f"{RL_CFG_NS}:*")
+        result = {}
+        for key in keys:
+            key_str = key.decode() if isinstance(key, bytes) else key
+            agent_name = key_str.split(":")[-1]
+            rpm, window = await self.get_limit(agent_name)
+            result[agent_name] = {"requests_per_minute": rpm, "window_seconds": window}
+        return result
+
+    # ── Rate limit check ────────────────────────────────────────────────────
+
+    async def check(self, agent_name: str) -> bool:
+        """Atomically check and record a request. Returns True if allowed."""
+        rpm, window = await self.get_limit(agent_name)
+        key = f"{RL_NS}:{agent_name}"
+        now = time.time()
+        req_id = str(uuid.uuid4())
+
+        sha = await self._get_lua_sha()
+        try:
+            result = await self._r.evalsha(sha, 1, key, now, window, rpm, req_id)
+        except aioredis.exceptions.NoScriptError:
+            # Redis restarted and evicted the script — reload and retry once
+            self._lua_sha = None
+            sha = await self._get_lua_sha()
+            result = await self._r.evalsha(sha, 1, key, now, window, rpm, req_id)
+
+        allowed = bool(result)
+        stat = "allowed" if allowed else "limited"
+        await self._r.hincrby(f"{RL_STATS_NS}:{agent_name}", stat, 1)
+        return allowed
+
+    # ── Queue management ────────────────────────────────────────────────────
+
+    def _get_queue(self, agent_name: str) -> asyncio.Queue:
+        if agent_name not in self._queues:
+            self._queues[agent_name] = asyncio.Queue(maxsize=settings.QUEUE_MAX_DEPTH)
+        return self._queues[agent_name]
+
+    async def enqueue(
+        self,
+        agent_name: str,
+        upstream_url: str,
+        body: dict,
+        headers: dict,
+        proxy_fn: Callable,
+    ) -> Any:
+        """
+        Queue a rate-limited request.
+
+        Returns the upstream response when the drain loop processes it.
+        Raises asyncio.QueueFull if the queue is at capacity.
+        Raises asyncio.TimeoutError if the request isn't processed within
+        QUEUE_TIMEOUT_SECONDS.
+        """
+        queue = self._get_queue(agent_name)
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future = loop.create_future()
+
+        queued = _QueuedRequest(
+            future=future,
+            upstream_url=upstream_url,
+            body=body,
+            headers=headers,
+        )
+
+        queue.put_nowait(queued)  # raises QueueFull immediately if at capacity
+        await self._r.hincrby(f"{RL_STATS_NS}:{agent_name}", "queued", 1)
+
+        self._ensure_drain(agent_name, proxy_fn)
+
+        # shield prevents the Future from being cancelled when the wait_for
+        # deadline fires — the drain loop can still resolve it for cleanup
+        return await asyncio.wait_for(
+            asyncio.shield(future), timeout=settings.QUEUE_TIMEOUT_SECONDS
+        )
+
+    def _ensure_drain(self, agent_name: str, proxy_fn: Callable) -> None:
+        task = self._drain_tasks.get(agent_name)
+        if task is None or task.done():
+            self._drain_tasks[agent_name] = asyncio.create_task(
+                self._drain_loop(agent_name, proxy_fn)
+            )
+
+    async def _drain_loop(self, agent_name: str, proxy_fn: Callable) -> None:
+        """
+        Per-agent background task that drains the queue one request at a time.
+        Re-checks the rate limit before each item so it respects the sliding window.
+        Self-terminates after 5 consecutive seconds of queue idleness.
+        """
+        queue = self._get_queue(agent_name)
+        idle_ticks = 0
+
+        while True:
+            try:
+                queued: _QueuedRequest = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                idle_ticks += 1
+                if idle_ticks >= 5:
+                    self._drain_tasks.pop(agent_name, None)
+                    return
+                await asyncio.sleep(1.0)
+                continue
+
+            idle_ticks = 0
+
+            if queued.future.cancelled():
+                queue.task_done()
+                continue
+
+            # Wait until the rate limit window allows the next request
+            while not await self.check(agent_name):
+                await asyncio.sleep(0.5)
+
+            try:
+                response = await proxy_fn(queued.upstream_url, queued.body, queued.headers)
+                if not queued.future.done():
+                    queued.future.set_result(response)
+            except Exception as exc:
+                if not queued.future.done():
+                    queued.future.set_exception(exc)
+            finally:
+                queue.task_done()
+
+    # ── Stats ───────────────────────────────────────────────────────────────
+
+    def queue_stats(self) -> dict:
+        return {
+            agent: {
+                "depth": q.qsize(),
+                "max_depth": settings.QUEUE_MAX_DEPTH,
+                "timeout_seconds": settings.QUEUE_TIMEOUT_SECONDS,
+            }
+            for agent, q in self._queues.items()
+        }
+
+    async def rate_limit_stats(self) -> dict:
+        keys = await self._r.keys(f"{RL_STATS_NS}:*")
+        result = {}
+        for key in keys:
+            key_str = key.decode() if isinstance(key, bytes) else key
+            agent_name = key_str.split(":")[-1]
+            raw = await self._r.hgetall(key)
+            result[agent_name] = {
+                (k.decode() if isinstance(k, bytes) else k): int(v)
+                for k, v in raw.items()
+            }
+        return result

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -26,7 +26,7 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: redis
+    container_name: nasiko-redis
     restart: unless-stopped
     ports:
       - "6379:6379"
@@ -218,6 +218,38 @@ services:
       timeout: 10s
       retries: 3
 
+  nasiko-request-manager:
+    build:
+      context: ./agent-gateway/request-manager
+      dockerfile: Dockerfile
+    container_name: nasiko-request-manager
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      REDIS_URL: redis://redis:6379/0
+      DEFAULT_RATE_LIMIT_RPM: "60"
+      RATE_LIMIT_WINDOW_SECONDS: "60"
+      QUEUE_MAX_DEPTH: "100"
+      QUEUE_TIMEOUT_SECONDS: "30"
+      DEFAULT_CACHE_TTL_SECONDS: "3600"
+      UPSTREAM_CONNECT_TIMEOUT: "10"
+      UPSTREAM_READ_TIMEOUT: "300"
+      LOG_LEVEL: "INFO"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://phoenix-observability:4317"
+      OTEL_SERVICE_NAME: "nasiko-request-manager"
+    ports:
+      - "8090:8090"
+    networks:
+      - app-network
+      - agents-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/manage/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   kong-service-registry:
     build:
       context: ./agent-gateway/registry
@@ -227,8 +259,11 @@ services:
     depends_on:
       kong-gateway:
         condition: service_healthy
+      nasiko-request-manager:
+        condition: service_healthy
     environment:
       KONG_ADMIN_URL: http://kong-gateway:8001
+      REQUEST_MANAGER_URL: "http://nasiko-request-manager:8090"
       DOCKER_SOCKET: /var/run/docker.sock
       REGISTRY_INTERVAL: 30
       AGENTS_NETWORK: agents-net


### PR DESCRIPTION
- New nasiko-request-manager FastAPI service (port 8090) providing:
  - Redis-backed response caching with case-insensitive key normalization
  - Sliding-window rate limiting per agent via atomic Lua script
  - asyncio queue for rate-limited requests with configurable depth/timeout
  - Chat history deduplication (removes repeated query+response pairs before proxying)
  - OpenTelemetry tracing exported to Phoenix observability
  - Analytics dashboard at /manage/dashboard matching Nasiko UI theme
  - Management API: cache clear, rate limit set/reset, per-agent request log

- registry.py: route all agent traffic through request-manager proxy
- docker-compose.local.yml: add nasiko-request-manager service, update kong-service-registry dependency and REQUEST_MANAGER_URL env