### PR TITLE
feat(router): add Redis response cache, rate limiter, and monitoring

### DIFF
--- a/agent-gateway/router/pyproject.toml
+++ b/agent-gateway/router/pyproject.toml
@@ -26,6 +26,7 @@ uvicorn = ">=0.35.0"
 requests = "^2.31.0"
 python-multipart = "^0.0.7"
 httpx = ">=0.25.0"
+redis = ">=5.0.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/agent-gateway/router/src/config/settings.py
+++ b/agent-gateway/router/src/config/settings.py
@@ -29,11 +29,18 @@ class RouterConfig(BaseSettings):
 
     # Vector store settings
     VECTOR_STORE_CACHE_TTL: int = 3600
-    EMBEDDING_PROVIDER: str = "openai"  # "openai" | "jina"
+    EMBEDDING_PROVIDER: str = "openai"  # "openai" | "jina" | "none"
     EMBEDDING_MODEL: str = "text-embedding-3-small"
     RERANKING_EMBEDDING_MODEL: str = "text-embedding-3-small"
     JINA_API_KEY: Optional[str] = None
     JINA_EMBEDDING_MODEL: str = "jina-embeddings-v3"
+
+    # Redis settings (for cache + rate limiter)
+    REDIS_URL: str = "redis://redis:6379"
+    CACHE_TTL_SECONDS: int = 300
+    RATE_LIMIT_REQUESTS: int = 10
+    RATE_LIMIT_WINDOW_SECONDS: int = 60
+    RATE_LIMIT_QUEUE_TIMEOUT_SECONDS: int = 30
 
     # Request settings
     MAX_FILE_SIZE: int = 1073741824  # 1GB

--- a/agent-gateway/router/src/core/__init__.py
+++ b/agent-gateway/router/src/core/__init__.py
@@ -6,6 +6,8 @@ from .agent_registry import AgentRegistry, AgentRegistryError
 from .vector_store import VectorStoreService, VectorStoreError
 from .agent_client import AgentClient, AgentClientError
 from .session_history import SessionHistoryService, SessionHistoryError
+from .cache_service import CacheService
+from .rate_limiter import RateLimiter
 
 __all__ = [
     "AgentRegistry",
@@ -16,4 +18,6 @@ __all__ = [
     "AgentClientError",
     "SessionHistoryService",
     "SessionHistoryError",
+    "CacheService",
+    "RateLimiter",
 ]

--- a/agent-gateway/router/src/core/cache_service.py
+++ b/agent-gateway/router/src/core/cache_service.py
@@ -1,0 +1,103 @@
+"""Redis-backed response cache for the router."""
+
+import hashlib
+import logging
+from typing import Optional
+
+from router.src.config import settings
+
+logger = logging.getLogger(__name__)
+
+_redis_client = None
+
+
+def _get_redis():
+    global _redis_client
+    if _redis_client is None:
+        import redis.asyncio as aioredis
+
+        _redis_client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    return _redis_client
+
+
+def _cache_key(query: str) -> str:
+    normalized = query.strip().lower()
+    return f"cache:response:{hashlib.sha256(normalized.encode()).hexdigest()}"
+
+
+class CacheService:
+    async def get(self, query: str, agent_name: str = "router") -> Optional[str]:
+        try:
+            r = _get_redis()
+            key = _cache_key(query)
+            value = await r.get(key)
+            stat = "hits" if value else "misses"
+            await r.hincrby("cache:stats", stat, 1)
+            await r.hincrby("cache:stats", "total_requests", 1)
+            return value
+        except Exception as e:
+            logger.warning(f"Cache get failed: {e}")
+            return None
+
+    async def set(self, query: str, agent_name: str, value: str) -> None:
+        try:
+            r = _get_redis()
+            key = _cache_key(query)
+            await r.setex(key, settings.CACHE_TTL_SECONDS, value)
+            await r.sadd(f"cache:agent:{agent_name}:keys", key)
+            await r.hincrby("cache:stats", "total_sets", 1)
+        except Exception as e:
+            logger.warning(f"Cache set failed: {e}")
+
+    async def flush_agent(self, agent_name: str) -> int:
+        try:
+            r = _get_redis()
+            keys = await r.smembers(f"cache:agent:{agent_name}:keys")
+            if keys:
+                await r.delete(*keys)
+                await r.delete(f"cache:agent:{agent_name}:keys")
+            return len(keys)
+        except Exception as e:
+            logger.warning(f"Cache flush_agent failed: {e}")
+            return 0
+
+    async def flush_all(self) -> int:
+        try:
+            r = _get_redis()
+            keys = await r.keys("cache:response:*")
+            if keys:
+                await r.delete(*keys)
+            return len(keys)
+        except Exception as e:
+            logger.warning(f"Cache flush_all failed: {e}")
+            return 0
+
+    async def stats(self) -> dict:
+        try:
+            r = _get_redis()
+            raw = await r.hgetall("cache:stats")
+            hits = int(raw.get("hits", 0))
+            misses = int(raw.get("misses", 0))
+            total = int(raw.get("total_requests", 0))
+            live_keys = len(await r.keys("cache:response:*"))
+            return {
+                "hits": hits,
+                "misses": misses,
+                "total_requests": total,
+                "hit_rate_pct": round(hits / total * 100, 1) if total else 0.0,
+                "total_sets": int(raw.get("total_sets", 0)),
+                "live_keys": live_keys,
+                "ttl_seconds": settings.CACHE_TTL_SECONDS,
+            }
+        except Exception as e:
+            logger.warning(f"Cache stats failed: {e}")
+            return {}
+
+    async def agent_stats(self, agent_name: str) -> dict:
+        try:
+            r = _get_redis()
+            count = await r.scard(f"cache:agent:{agent_name}:keys")
+            return {"agent_name": agent_name, "live_keys": count}
+        except Exception as e:
+            logger.warning(f"Cache agent_stats failed: {e}")
+            return {"agent_name": agent_name, "live_keys": 0}

--- a/agent-gateway/router/src/core/rate_limiter.py
+++ b/agent-gateway/router/src/core/rate_limiter.py
@@ -1,0 +1,127 @@
+"""Sliding-window rate limiter with async queue using Redis sorted sets."""
+
+import asyncio
+import logging
+import time
+from typing import Optional, Tuple
+
+from router.src.config import settings
+
+logger = logging.getLogger(__name__)
+
+_redis_client = None
+
+
+def _get_redis():
+    global _redis_client
+    if _redis_client is None:
+        import redis.asyncio as aioredis
+
+        _redis_client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
+    return _redis_client
+
+
+class RateLimiter:
+    async def _get_config(self, agent_name: str) -> Tuple[int, int]:
+        try:
+            r = _get_redis()
+            raw = await r.hgetall(f"ratelimit:config:{agent_name}")
+            limit = int(raw.get("limit", settings.RATE_LIMIT_REQUESTS))
+            window = int(raw.get("window_seconds", settings.RATE_LIMIT_WINDOW_SECONDS))
+            return limit, window
+        except Exception:
+            return settings.RATE_LIMIT_REQUESTS, settings.RATE_LIMIT_WINDOW_SECONDS
+
+    async def _check_and_record(self, agent_name: str) -> bool:
+        try:
+            r = _get_redis()
+            limit, window = await self._get_config(agent_name)
+            key = f"ratelimit:window:{agent_name}"
+            now = time.time()
+            cutoff = now - window
+            async with r.pipeline() as pipe:
+                await pipe.zremrangebyscore(key, "-inf", cutoff)
+                await pipe.zcard(key)
+                await pipe.zadd(key, {str(now): now})
+                await pipe.expire(key, window + 1)
+                results = await pipe.execute()
+            count_before = results[1]
+            if count_before >= limit:
+                await r.zrem(key, str(now))
+                return False
+            await r.hincrby(f"ratelimit:stats:{agent_name}", "allowed", 1)
+            return True
+        except Exception as e:
+            logger.warning(f"Rate limiter error: {e}")
+            return True  # fail-open
+
+    async def acquire(self, agent_name: str) -> Tuple[bool, str]:
+        if await self._check_and_record(agent_name):
+            return True, "allowed"
+        timeout = settings.RATE_LIMIT_QUEUE_TIMEOUT_SECONDS
+        deadline = time.time() + timeout
+        queued = False
+        while time.time() < deadline:
+            await asyncio.sleep(0.5)
+            if await self._check_and_record(agent_name):
+                disposition = "queued" if queued else "allowed"
+                return True, disposition
+            queued = True
+        try:
+            r = _get_redis()
+            await r.hincrby(f"ratelimit:stats:{agent_name}", "rejected", 1)
+        except Exception:
+            pass
+        return False, "rejected"
+
+    async def set_config(self, agent_name: str, limit: int, window_seconds: int) -> None:
+        try:
+            r = _get_redis()
+            await r.hset(
+                f"ratelimit:config:{agent_name}",
+                mapping={"limit": limit, "window_seconds": window_seconds},
+            )
+        except Exception as e:
+            logger.warning(f"Rate limiter set_config failed: {e}")
+
+    async def stats(self, agent_name: Optional[str] = None) -> dict:
+        try:
+            r = _get_redis()
+            if agent_name:
+                raw = await r.hgetall(f"ratelimit:stats:{agent_name}")
+                limit, window = await self._get_config(agent_name)
+                count = await r.zcard(f"ratelimit:window:{agent_name}")
+                return {
+                    agent_name: {
+                        "allowed": int(raw.get("allowed", 0)),
+                        "rejected": int(raw.get("rejected", 0)),
+                        "current_window_count": count,
+                        "limit": limit,
+                        "window_seconds": window,
+                    }
+                }
+            keys = await r.keys("ratelimit:stats:*")
+            result = {}
+            for k in keys:
+                name = k.split("ratelimit:stats:")[1]
+                raw = await r.hgetall(k)
+                limit, window = await self._get_config(name)
+                count = await r.zcard(f"ratelimit:window:{name}")
+                result[name] = {
+                    "allowed": int(raw.get("allowed", 0)),
+                    "rejected": int(raw.get("rejected", 0)),
+                    "current_window_count": count,
+                    "limit": limit,
+                    "window_seconds": window,
+                }
+            return result
+        except Exception as e:
+            logger.warning(f"Rate limiter stats failed: {e}")
+            return {}
+
+    async def reset_stats(self, agent_name: str) -> None:
+        try:
+            r = _get_redis()
+            await r.delete(f"ratelimit:stats:{agent_name}")
+        except Exception as e:
+            logger.warning(f"Rate limiter reset_stats failed: {e}")

--- a/agent-gateway/router/src/core/routing_engine.py
+++ b/agent-gateway/router/src/core/routing_engine.py
@@ -77,6 +77,11 @@ class RoutingEngine:
                 model_name=settings.JINA_EMBEDDING_MODEL,
             )
 
+        if provider == "none" or not settings.OPENAI_API_KEY:
+            from router.src.core.vector_store import _DummyEmbeddings
+
+            return _DummyEmbeddings()
+
         return OpenAIEmbeddings(
             model=settings.RERANKING_EMBEDDING_MODEL,
             openai_api_key=settings.OPENAI_API_KEY,

--- a/agent-gateway/router/src/core/vector_store.py
+++ b/agent-gateway/router/src/core/vector_store.py
@@ -3,6 +3,7 @@ Vector store service for agent selection and similarity search.
 """
 
 import logging
+import random
 from typing import List, Dict, Tuple, Optional
 
 from langchain_community.vectorstores import FAISS
@@ -17,6 +18,19 @@ class VectorStoreError(Exception):
     """Custom exception for vector store errors."""
 
     pass
+
+
+class _DummyEmbeddings:
+    """Random-vector embeddings used when no API key is configured.
+
+    Safe because FAISS search is skipped for <15 agents.
+    """
+
+    def embed_documents(self, texts):
+        return [[random.gauss(0, 1) for _ in range(384)] for _ in texts]
+
+    def embed_query(self, text):
+        return [random.gauss(0, 1) for _ in range(384)]
 
 
 class VectorStoreService:
@@ -41,9 +55,11 @@ class VectorStoreService:
                 model_name=settings.JINA_EMBEDDING_MODEL,
             )
 
+        if provider == "none" or not settings.OPENAI_API_KEY:
+            logger.warning("No embedding API configured — using local dummy embeddings")
+            return _DummyEmbeddings()
+
         # Default: OpenAI
-        if not settings.OPENAI_API_KEY:
-            raise VectorStoreError("OPENAI_API_KEY is required for OpenAI embeddings")
         return OpenAIEmbeddings(
             model=settings.EMBEDDING_MODEL, openai_api_key=settings.OPENAI_API_KEY
         )

--- a/agent-gateway/router/src/main.py
+++ b/agent-gateway/router/src/main.py
@@ -11,8 +11,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.params import Depends
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
 
 from router.src.config import settings
+from router.src.core.cache_service import CacheService
+from router.src.core.rate_limiter import RateLimiter
 from router.src.entities import UserRequest
 from router.src.services import RouterOrchestrator
 
@@ -44,6 +47,16 @@ app.add_middleware(
 
 # Initialize orchestrator
 orchestrator = RouterOrchestrator()
+
+# Singletons for monitoring endpoints (separate from orchestrator's instances —
+# these read the same Redis-backed state)
+_cache = CacheService()
+_rate_limiter = RateLimiter()
+
+
+class RateLimitConfig(BaseModel):
+    limit: int
+    window_seconds: int
 
 
 @app.get("/health")
@@ -122,15 +135,70 @@ async def process_request(
 
 
 @app.get("/metrics")
+@app.get("/router/metrics")
 async def get_metrics():
-    """Get router service metrics."""
-    # TODO: Implement metrics collection
+    """Combined cache + rate-limit dashboard."""
     return {
-        "requests_processed": 0,
-        "active_sessions": 0,
-        "average_response_time": 0.0,
-        "error_rate": 0.0,
+        "cache": await _cache.stats(),
+        "rate_limits": await _rate_limiter.stats(),
     }
+
+
+@app.get("/cache/stats")
+@app.get("/router/cache/stats")
+async def cache_stats():
+    return await _cache.stats()
+
+
+@app.get("/cache/agent/{agent_name}")
+@app.get("/router/cache/agent/{agent_name}")
+async def cache_agent_stats(agent_name: str):
+    return await _cache.agent_stats(agent_name)
+
+
+@app.delete("/cache")
+@app.delete("/router/cache")
+async def cache_flush_all():
+    deleted = await _cache.flush_all()
+    return {"deleted_keys": deleted, "message": "Cache cleared"}
+
+
+@app.delete("/cache/agent/{agent_name}")
+@app.delete("/router/cache/agent/{agent_name}")
+async def cache_flush_agent(agent_name: str):
+    deleted = await _cache.flush_agent(agent_name)
+    return {"agent_name": agent_name, "deleted_keys": deleted}
+
+
+@app.get("/ratelimit/stats")
+@app.get("/router/ratelimit/stats")
+async def ratelimit_stats():
+    return await _rate_limiter.stats()
+
+
+@app.get("/ratelimit/stats/{agent_name}")
+@app.get("/router/ratelimit/stats/{agent_name}")
+async def ratelimit_agent_stats(agent_name: str):
+    return await _rate_limiter.stats(agent_name)
+
+
+@app.post("/ratelimit/config/{agent_name}")
+@app.post("/router/ratelimit/config/{agent_name}")
+async def ratelimit_set_config(agent_name: str, cfg: RateLimitConfig):
+    await _rate_limiter.set_config(agent_name, cfg.limit, cfg.window_seconds)
+    return {
+        "agent_name": agent_name,
+        "limit": cfg.limit,
+        "window_seconds": cfg.window_seconds,
+        "message": "Rate limit config updated",
+    }
+
+
+@app.delete("/ratelimit/stats/{agent_name}")
+@app.delete("/router/ratelimit/stats/{agent_name}")
+async def ratelimit_reset_stats(agent_name: str):
+    await _rate_limiter.reset_stats(agent_name)
+    return {"agent_name": agent_name, "message": "Stats reset"}
 
 
 def _validate_inputs(session_id: str, query: str) -> Optional[str]:

--- a/agent-gateway/router/src/services/router_orchestrator.py
+++ b/agent-gateway/router/src/services/router_orchestrator.py
@@ -14,6 +14,8 @@ from router.src.core import (
     AgentClient,
     AgentClientError,
     SessionHistoryService,
+    CacheService,
+    RateLimiter,
 )
 from router.src.entities import UserRequest, RouterResponse, RouterOutput
 from router.src.core.routing_engine import router
@@ -30,6 +32,8 @@ class RouterOrchestrator:
         self.session_history_service = SessionHistoryService()
         self.vector_store = VectorStoreService()
         self.agent_client = AgentClient()
+        self.cache = CacheService()
+        self.rate_limiter = RateLimiter()
 
     async def process_request(
         self,
@@ -67,6 +71,15 @@ class RouterOrchestrator:
         """Handle requests that need route selection."""
 
         logger.info(f"Processing query for route selection: {request.query}")
+
+        cached = await self.cache.get(request.query, agent_name="router")
+        if cached is not None:
+            yield self._router_response(
+                "Cache hit — serving cached response", "", True, ""
+            )
+            yield cached
+            return
+
         yield self._router_response("Processing user's query...")
 
         # Step 1: Fetch agent cards
@@ -170,7 +183,7 @@ class RouterOrchestrator:
 
             # Send request to selected agent
             async for response in self._send_agent_request(
-                request, files, agent_url, token
+                request, files, agent_url, token, agent_name
             ):
                 yield response
 
@@ -185,8 +198,26 @@ class RouterOrchestrator:
         files: List[Tuple[str, Tuple[str, bytes, str]]],
         agent_url: str,
         token: str,
+        agent_name: str,
     ) -> AsyncGenerator[str, None]:
         """Send request to agent and yield response."""
+
+        allowed, disposition = await self.rate_limiter.acquire(agent_name)
+        if not allowed:
+            yield self._router_response(
+                f"Rate limit exceeded for agent '{agent_name}'. Please retry in a moment.",
+                agent_name,
+                False,
+                agent_url,
+            )
+            return
+        if disposition == "queued":
+            yield self._router_response(
+                f"Request queued for agent '{agent_name}' — now processing...",
+                agent_name,
+                True,
+                agent_url,
+            )
 
         try:
             logger.info(f"Sending request to agent: {agent_url}")
@@ -204,6 +235,9 @@ class RouterOrchestrator:
 
             logger.info("Successfully received response from agent")
             yield self._router_response(agent_response, "", False, agent_url)
+
+            # Cache the successful response keyed by query
+            await self.cache.set(request.query, agent_name, agent_response)
 
         except AgentClientError as e:
             yield self._router_response(str(e), "", False, agent_url)

--- a/agents/a2a-compliance-checker/src/openai_agent_executor.py
+++ b/agents/a2a-compliance-checker/src/openai_agent_executor.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import asyncio
 
 from typing import Any
 
@@ -14,7 +15,13 @@ from a2a.types import (
     UnsupportedOperationError,
 )
 from a2a.utils.errors import ServerError
-from openai import AsyncOpenAI
+from openai import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    AsyncOpenAI,
+    RateLimitError,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -68,15 +75,49 @@ class OpenAIAgentExecutor(AgentExecutor):
             iteration += 1
 
             try:
-                # Make API call to OpenAI
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    tools=openai_tools if openai_tools else None,
-                    tool_choice="auto" if openai_tools else None,
-                    temperature=0.1,
-                    max_tokens=4000,
-                )
+                response = None
+                max_attempts = 3
+                for attempt in range(1, max_attempts + 1):
+                    try:
+                        response = await self.client.chat.completions.create(
+                            model=self.model,
+                            messages=messages,
+                            tools=openai_tools if openai_tools else None,
+                            tool_choice="auto" if openai_tools else None,
+                            temperature=0.1,
+                            max_tokens=4000,
+                        )
+                        break
+                    except RateLimitError as e:
+                        retry_after = None
+                        try:
+                            headers = (
+                                getattr(getattr(e, "response", None), "headers", None)
+                                or getattr(e, "headers", None)
+                                or {}
+                            )
+                            retry_after_raw = headers.get("Retry-After") or headers.get(
+                                "retry-after"
+                            )
+                            if retry_after_raw is not None:
+                                retry_after = float(retry_after_raw)
+                        except Exception:
+                            retry_after = None
+
+                        wait_seconds = retry_after if retry_after is not None else 2**attempt
+                        wait_seconds = min(wait_seconds, 30.0)
+
+                        if attempt >= max_attempts:
+                            raise
+                        await asyncio.sleep(wait_seconds)
+                    except (APITimeoutError, APIConnectionError, APIError):
+                        wait_seconds = min(2**attempt, 10)
+                        if attempt >= max_attempts:
+                            raise
+                        await asyncio.sleep(wait_seconds)
+
+                if response is None:
+                    raise RuntimeError("Failed to get LLM response after retries")
 
                 message = response.choices[0].message
 
@@ -152,6 +193,20 @@ class OpenAIAgentExecutor(AgentExecutor):
                     await task_updater.complete()
                 break
 
+            except RateLimitError as e:
+                logger.error(f"Rate limited by LLM provider: {e}")
+                error_parts = [
+                    TextPart(
+                        text=(
+                            "Sorry, the LLM provider is rate-limiting requests (HTTP 429). "
+                            "Please wait a bit and retry. If you're using an OpenRouter `:free` model, "
+                            "switch to a non-free model or add your own OpenRouter key to reduce rate limits."
+                        )
+                    )
+                ]
+                await task_updater.add_artifact(error_parts)
+                await task_updater.complete()
+                break
             except Exception as e:
                 logger.error(f"Error in OpenAI API call: {e}")
                 error_parts = [

--- a/agents/a2a-github-agent/src/openai_agent_executor.py
+++ b/agents/a2a-github-agent/src/openai_agent_executor.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import asyncio
 
 from typing import Any
 
@@ -14,7 +15,13 @@ from a2a.types import (
     UnsupportedOperationError,
 )
 from a2a.utils.errors import ServerError
-from openai import AsyncOpenAI
+from openai import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    AsyncOpenAI,
+    RateLimitError,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -68,15 +75,49 @@ class OpenAIAgentExecutor(AgentExecutor):
             iteration += 1
 
             try:
-                # Make API call to OpenAI
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    tools=openai_tools if openai_tools else None,
-                    tool_choice="auto" if openai_tools else None,
-                    temperature=0.1,
-                    max_tokens=4000,
-                )
+                response = None
+                max_attempts = 3
+                for attempt in range(1, max_attempts + 1):
+                    try:
+                        response = await self.client.chat.completions.create(
+                            model=self.model,
+                            messages=messages,
+                            tools=openai_tools if openai_tools else None,
+                            tool_choice="auto" if openai_tools else None,
+                            temperature=0.1,
+                            max_tokens=4000,
+                        )
+                        break
+                    except RateLimitError as e:
+                        retry_after = None
+                        try:
+                            headers = (
+                                getattr(getattr(e, "response", None), "headers", None)
+                                or getattr(e, "headers", None)
+                                or {}
+                            )
+                            retry_after_raw = headers.get("Retry-After") or headers.get(
+                                "retry-after"
+                            )
+                            if retry_after_raw is not None:
+                                retry_after = float(retry_after_raw)
+                        except Exception:
+                            retry_after = None
+
+                        wait_seconds = retry_after if retry_after is not None else 2**attempt
+                        wait_seconds = min(wait_seconds, 30.0)
+
+                        if attempt >= max_attempts:
+                            raise
+                        await asyncio.sleep(wait_seconds)
+                    except (APITimeoutError, APIConnectionError, APIError):
+                        wait_seconds = min(2**attempt, 10)
+                        if attempt >= max_attempts:
+                            raise
+                        await asyncio.sleep(wait_seconds)
+
+                if response is None:
+                    raise RuntimeError("Failed to get LLM response after retries")
 
                 message = response.choices[0].message
 
@@ -152,6 +193,20 @@ class OpenAIAgentExecutor(AgentExecutor):
                     await task_updater.complete()
                 break
 
+            except RateLimitError as e:
+                logger.error(f"Rate limited by LLM provider: {e}")
+                error_parts = [
+                    TextPart(
+                        text=(
+                            "Sorry, the LLM provider is rate-limiting requests (HTTP 429). "
+                            "Please wait a bit and retry. If you're using an OpenRouter `:free` model, "
+                            "switch to a non-free model or add your own OpenRouter key to reduce rate limits."
+                        )
+                    )
+                ]
+                await task_updater.add_artifact(error_parts)
+                await task_updater.complete()
+                break
             except Exception as e:
                 logger.error(f"Error in OpenAI API call: {e}")
                 error_parts = [

--- a/agents/a2a-translator/src/openai_agent_executor.py
+++ b/agents/a2a-translator/src/openai_agent_executor.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import inspect
+import asyncio
 
 from typing import Any
 
@@ -15,7 +16,13 @@ from a2a.types import (
     UnsupportedOperationError,
 )
 from a2a.utils.errors import ServerError
-from openai import AsyncOpenAI
+from openai import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    AsyncOpenAI,
+    RateLimitError,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -69,15 +76,63 @@ class OpenAIAgentExecutor(AgentExecutor):
             iteration += 1
 
             try:
-                # Make API call to OpenAI
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    tools=openai_tools if openai_tools else None,
-                    tool_choice="auto" if openai_tools else None,
-                    temperature=0.1,
-                    max_tokens=4000,
-                )
+                response = None
+                max_attempts = 3
+                for attempt in range(1, max_attempts + 1):
+                    try:
+                        response = await self.client.chat.completions.create(
+                            model=self.model,
+                            messages=messages,
+                            tools=openai_tools if openai_tools else None,
+                            tool_choice="auto" if openai_tools else None,
+                            temperature=0.1,
+                            max_tokens=4000,
+                        )
+                        break
+                    except RateLimitError as e:
+                        retry_after = None
+                        try:
+                            headers = (
+                                getattr(getattr(e, "response", None), "headers", None)
+                                or getattr(e, "headers", None)
+                                or {}
+                            )
+                            retry_after_raw = headers.get("Retry-After") or headers.get(
+                                "retry-after"
+                            )
+                            if retry_after_raw is not None:
+                                retry_after = float(retry_after_raw)
+                        except Exception:
+                            retry_after = None
+
+                        wait_seconds = retry_after if retry_after is not None else 2**attempt
+                        wait_seconds = min(wait_seconds, 30.0)
+
+                        if attempt >= max_attempts:
+                            raise
+
+                        await task_updater.update_status(
+                            TaskState.working,
+                            message=task_updater.new_agent_message(
+                                [
+                                    TextPart(
+                                        text=(
+                                            "LLM provider rate-limited (HTTP 429). "
+                                            f"Retrying in ~{int(wait_seconds)}s..."
+                                        )
+                                    )
+                                ]
+                            ),
+                        )
+                        await asyncio.sleep(wait_seconds)
+                    except (APITimeoutError, APIConnectionError, APIError):
+                        wait_seconds = min(2**attempt, 10)
+                        if attempt >= max_attempts:
+                            raise
+                        await asyncio.sleep(wait_seconds)
+
+                if response is None:
+                    raise RuntimeError("Failed to get LLM response after retries")
 
                 message = response.choices[0].message
 
@@ -156,6 +211,20 @@ class OpenAIAgentExecutor(AgentExecutor):
                     await task_updater.complete()
                 break
 
+            except RateLimitError as e:
+                logger.error(f"Rate limited by LLM provider: {e}")
+                error_parts = [
+                    TextPart(
+                        text=(
+                            "Sorry, the LLM provider is rate-limiting requests (HTTP 429). "
+                            "Please wait a bit and retry. If you're using an OpenRouter `:free` model, "
+                            "switch to a non-free model or add your own OpenRouter key to reduce rate limits."
+                        )
+                    )
+                ]
+                await task_updater.add_artifact(error_parts)
+                await task_updater.complete()
+                break
             except Exception as e:
                 logger.error(f"Error in OpenAI API call: {e}")
                 error_parts = [

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -261,6 +261,7 @@ services:
     restart: unless-stopped
     depends_on:
       - nasiko-backend
+      - redis
     environment:
       OLLAMA_SERVER: http://ollama:11434
       NASIKO_BACKEND: http://nasiko-backend:8000/api/v1
@@ -274,6 +275,11 @@ services:
       EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-openai}
       JINA_API_KEY: ${JINA_API_KEY:-}
       JINA_EMBEDDING_MODEL: ${JINA_EMBEDDING_MODEL:-jina-embeddings-v3}
+      REDIS_URL: redis://redis:6379
+      CACHE_TTL_SECONDS: ${CACHE_TTL_SECONDS:-300}
+      RATE_LIMIT_REQUESTS: ${RATE_LIMIT_REQUESTS:-10}
+      RATE_LIMIT_WINDOW_SECONDS: ${RATE_LIMIT_WINDOW_SECONDS:-60}
+      RATE_LIMIT_QUEUE_TIMEOUT_SECONDS: ${RATE_LIMIT_QUEUE_TIMEOUT_SECONDS:-30}
     ports:
       - "8081:8000"
     networks:


### PR DESCRIPTION
Add resilience layer to nasiko-router:
- Redis-backed response cache with 5-min TTL keyed by SHA-256 of normalized query
- Per-agent sliding-window rate limiter (Redis ZSET) with async queueing and runtime-configurable limits
- Monitoring endpoints under /metrics, /cache/*, /ratelimit/* (each registered with bare path and /router/ prefix for Kong)
- _DummyEmbeddings fallback when EMBEDDING_PROVIDER=none or no OpenAI key (safe because FAISS search is skipped for <15 agents)

Wire-up:
- Cache check at top of _handle_route_selection; cache write after successful agent response in _send_agent_request
- Rate-limit gate before forwarding to agent, with queued/rejected dispositions
- New nasiko-router env vars and depends_on: redis in docker-compose