### PR TITLE
feat(web): Titan Builder challenges 1 and 2 metrics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!web/metrics-dashboard/lib/
 lib64/
 parts/
 sdist/
@@ -158,6 +159,7 @@ cython_debug/
 
 # macOS files
 .DS_Store
+*.dmg
 
 # Sensitive credentials
 superuser_credentials.json

--- a/web/metrics-dashboard/.env.example
+++ b/web/metrics-dashboard/.env.example
@@ -1,0 +1,12 @@
+# Nasiko API base URL (used by Route Handlers on the server only)
+
+# Local dev — Kong gateway on the host
+NASIKO_API_URL=http://localhost:9100
+
+# Docker Compose — metrics container on app-network (uncomment when wired in compose)
+# NASIKO_API_URL=http://nasiko-backend:8000
+# Or via Kong from another container:
+# NASIKO_API_URL=http://kong-gateway:8000
+
+# Optional — Phoenix reads from Next server only (Phase B5+)
+# PHOENIX_URL=http://localhost:6006

--- a/web/metrics-dashboard/.gitignore
+++ b/web/metrics-dashboard/.gitignore
@@ -1,0 +1,25 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+npm-debug.log*
+.env*.local
+
+# typescript
+next-env.d.ts

--- a/web/metrics-dashboard/README.md
+++ b/web/metrics-dashboard/README.md
@@ -1,0 +1,90 @@
+# Nasiko Metrics Dashboard
+
+Hackathon **Challenge 2** — per-agent performance metrics (latency, success/error, uptime, 24h chart).
+
+**Status:** API + UI working on http://localhost:3003 (Phases B & C complete).
+
+## Features
+
+- Agent selector (Nasiko registry)
+- KPI cards: avg response time, success, errors, uptime %
+- 24h latency line chart (Recharts)
+- Loading, error, no-data, and auth states
+- Dark theme aligned with Nasiko shell
+
+## Development
+
+```bash
+npm install
+cp .env.example .env.local
+npm run dev
+```
+
+Open **http://localhost:3003**
+
+### Auth (important for port 3003)
+
+The main Nasiko app runs on **port 9100**; metrics dev runs on **3003**. Browser `localStorage` is not shared across ports.
+
+1. Sign in at http://localhost:9100/app/
+2. Open DevTools → Application → Local Storage → `localhost:9100`
+3. Copy `access_token` from key `nasiko-credentials-{email}-{username}.json`
+4. Paste on the metrics dashboard sign-in screen
+
+When deployed behind Kong at `/app/metrics/` on the same host, the token is read automatically.
+
+## Scripts
+
+| Command | Purpose |
+|---------|---------|
+| `npm run dev` | Dev server on port 3003 |
+| `npm run build` | Production build |
+| `npm run test` | Vitest — rollup unit tests |
+| `npm run smoke` | API smoke test (needs `NASIKO_BEARER_TOKEN`) |
+
+## API smoke (curl)
+
+```bash
+curl http://localhost:3003/api/health
+
+curl http://localhost:3003/api/agents \
+  -H "Authorization: Bearer <access_token>"
+
+curl "http://localhost:3003/api/metrics?agent=a2a-translator&window=24h" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+```bash
+export NASIKO_BEARER_TOKEN="<access_token>"
+npm run smoke
+```
+
+## Environment
+
+| Variable | Description |
+|----------|-------------|
+| `NASIKO_API_URL` | Kong gateway (server, default `http://localhost:9100`) |
+| `NEXT_PUBLIC_NASIKO_APP_URL` | Main app link (default `http://localhost:9100/app/`) |
+
+## Architecture
+
+```
+Browser → /api/agents, /api/metrics (Next Route Handlers)
+       → Nasiko API (Bearer forwarded)
+       → Observability stats + sessions + Kong agent health
+```
+
+Vault docs: `vault/reference/metrics-dashboard-dev.md`
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| HTML 500 from API routes | `rm -rf .next && npm run dev` |
+| Sign-in loop on :3003 | Paste token from :9100 credentials key |
+| Empty metrics / `no_data` | Use agent in main UI to generate Phoenix traces |
+| Agent chat 401 | Fix `.nasiko-local.env` LLM keys; redeploy agent |
+
+## Production
+
+Target: Kong route `/app/metrics/` (docker-compose wiring — Phase D).

--- a/web/metrics-dashboard/app/api/agents/route.ts
+++ b/web/metrics-dashboard/app/api/agents/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getBearerAuthForNasiko, unauthorizedResponse } from "@/lib/auth";
+import { fetchNasikoUserAgents, NasikoApiError } from "@/lib/nasiko";
+import type { MetricsAgentOption } from "@/lib/types";
+
+/**
+ * Proxy to Nasiko GET /api/v1/registry/user/agents for the agent selector (B3).
+ */
+export async function GET(request: Request) {
+  const authorization = getBearerAuthForNasiko(request);
+  if (!authorization) {
+    return unauthorizedResponse();
+  }
+
+  try {
+    const nasikoResponse = await fetchNasikoUserAgents(authorization);
+
+    const agents: MetricsAgentOption[] = (nasikoResponse.data ?? []).map(
+      (agent) => ({
+        agentId: agent.agent_id,
+        name: agent.name,
+        description: agent.description ?? null,
+        tags: agent.tags ?? [],
+      }),
+    );
+
+    return NextResponse.json({
+      agents,
+      statusCode: nasikoResponse.status_code,
+      message: nasikoResponse.message,
+    });
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      let detail: unknown = err.body;
+      try {
+        detail = JSON.parse(err.body);
+      } catch {
+        /* keep raw body */
+      }
+      return NextResponse.json(
+        { error: err.message, detail },
+        { status: err.status >= 400 && err.status < 600 ? err.status : 502 },
+      );
+    }
+
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/metrics-dashboard/app/api/health/route.ts
+++ b/web/metrics-dashboard/app/api/health/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import {
+  fetchNasikoBackendHealthcheck,
+  fetchNasikoGatewayHealth,
+  getNasikoApiUrl,
+  NasikoApiError,
+} from "@/lib/nasiko";
+
+/**
+ * B2 smoke test: confirms Next server can reach Nasiko via NASIKO_API_URL.
+ * GET /api/health — no user auth required.
+ */
+export async function GET() {
+  const nasikoApiUrl = getNasikoApiUrl();
+
+  try {
+    const [gateway, backend] = await Promise.all([
+      fetchNasikoGatewayHealth(),
+      fetchNasikoBackendHealthcheck(),
+    ]);
+
+    return NextResponse.json({
+      ok: true,
+      nasikoApiUrl,
+      gateway,
+      backend,
+    });
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          nasikoApiUrl,
+          error: err.message,
+          status: err.status,
+          body: err.body,
+        },
+        { status: 502 },
+      );
+    }
+
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, nasikoApiUrl, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/web/metrics-dashboard/app/api/logs/route.ts
+++ b/web/metrics-dashboard/app/api/logs/route.ts
@@ -1,0 +1,91 @@
+/**
+ * Challenge 1 — GET /api/logs
+ *
+ * Synthesizes a "platform activity log" from existing Nasiko observability
+ * sessions + registry data. No Nasiko API changes; no Docker access; runs
+ * anywhere the dashboard runs.
+ *
+ * Query params:
+ *   window=24h   (default; only 24h is supported today)
+ */
+
+import { NextResponse } from "next/server";
+import { getBearerAuthForNasiko, unauthorizedResponse } from "@/lib/auth";
+import { computeStartTimeIso, parseMetricsWindow } from "@/lib/metrics";
+import {
+  fetchNasikoObservabilitySessions,
+  fetchNasikoUserAgents,
+  NasikoApiError,
+} from "@/lib/nasiko";
+import { synthesizeLogs } from "@/lib/logs";
+import type { LogsResponse } from "@/lib/types";
+
+export async function GET(request: Request) {
+  const authorization = getBearerAuthForNasiko(request);
+  if (!authorization) {
+    return unauthorizedResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const windowResult = parseMetricsWindow(searchParams.get("window"));
+  if ("error" in windowResult) {
+    return NextResponse.json({ error: windowResult.error }, { status: 400 });
+  }
+
+  const startTimeIso = computeStartTimeIso(windowResult.hours);
+  const now = new Date();
+
+  try {
+    const [agentsResponse, sessionsResponse] = await Promise.all([
+      fetchNasikoUserAgents(authorization).catch((err) => {
+        // Registry is best-effort — if it fails, we still ship session rows.
+        if (err instanceof NasikoApiError && err.status === 401) {
+          throw err;
+        }
+        return { data: [], status_code: 0, message: "" };
+      }),
+      fetchNasikoObservabilitySessions(authorization, startTimeIso).catch(
+        (err) => {
+          if (err instanceof NasikoApiError && err.status === 401) {
+            throw err;
+          }
+          return { data: { sessions: [] } };
+        },
+      ),
+    ]);
+
+    const sessions = sessionsResponse.data?.sessions ?? [];
+    const agents = agentsResponse.data ?? [];
+
+    const { logs, source_counts } = synthesizeLogs({
+      sessions,
+      agents,
+      generatedAt: now,
+    });
+
+    const body: LogsResponse = {
+      window: windowResult.window,
+      generated_at: now.toISOString(),
+      total: logs.length,
+      source_counts,
+      logs,
+    };
+
+    return NextResponse.json(body);
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      let detail: unknown = err.body;
+      try {
+        detail = JSON.parse(err.body);
+      } catch {
+        /* keep raw body */
+      }
+      return NextResponse.json(
+        { error: err.message, detail },
+        { status: err.status >= 400 && err.status < 600 ? err.status : 502 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/metrics-dashboard/app/api/metrics/route.ts
+++ b/web/metrics-dashboard/app/api/metrics/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { getBearerAuthForNasiko, unauthorizedResponse } from "@/lib/auth";
+import { emptyAgentMetrics } from "@/lib/metrics";
+import { filterNasikoSessionsInRange } from "@/lib/session-filters";
+import { parseTimeRangeQuery } from "@/lib/time-range";
+import {
+  fetchNasikoAgentStats,
+  fetchNasikoObservabilitySessions,
+  NasikoApiError,
+} from "@/lib/nasiko";
+import { buildAgentMetrics } from "@/lib/rollup";
+import { recordAgentHealth } from "@/lib/uptime";
+import type { NasikoObservabilitySession } from "@/lib/types";
+
+/**
+ * B4–B6: Nasiko stats + session rollup + Kong health uptime.
+ * Query: `agent` (registry agentId), `window` (default `24h`).
+ */
+export async function GET(request: Request) {
+  const authorization = getBearerAuthForNasiko(request);
+  if (!authorization) {
+    return unauthorizedResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const agent = searchParams.get("agent")?.trim();
+  if (!agent) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: agent" },
+      { status: 400 },
+    );
+  }
+
+  const rangeResult = parseTimeRangeQuery(searchParams);
+  if ("error" in rangeResult) {
+    return NextResponse.json({ error: rangeResult.error }, { status: 400 });
+  }
+  const range = rangeResult;
+  const startTimeIso = range.startTimeIso;
+
+  try {
+    const [statsResponse, sessionsResponse, uptimeResult] = await Promise.all([
+      fetchNasikoAgentStats(authorization, agent, startTimeIso),
+      fetchNasikoObservabilitySessions(authorization, startTimeIso).catch(
+        () => ({ data: { sessions: [] as NasikoObservabilitySession[] } }),
+      ),
+      recordAgentHealth(agent),
+    ]);
+
+    const project = statsResponse.data?.project;
+    if (!project) {
+      return NextResponse.json(
+        {
+          error: "No observability data for agent",
+          agent,
+          detail: "Project stats empty — deploy the agent and generate traces.",
+        },
+        { status: 404 },
+      );
+    }
+
+    const sessions = filterNasikoSessionsInRange(
+      (sessionsResponse.data?.sessions ?? []).filter((s) => s.agent_id === agent),
+      range.startMs,
+      range.endMs,
+    );
+
+    const metrics = buildAgentMetrics({
+      agentId: agent,
+      window: range.window,
+      hours: range.hours,
+      project,
+      sessions,
+      uptimePct: uptimeResult.uptimePct,
+      uptimeMeta: uptimeResult.meta,
+      now: range.endMs,
+    });
+
+    return NextResponse.json(metrics);
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      let detail: unknown = err.body;
+      try {
+        detail = JSON.parse(err.body);
+      } catch {
+        /* keep raw body */
+      }
+
+      if (err.status === 404) {
+        const detailStr =
+          typeof detail === "object" &&
+          detail !== null &&
+          "detail" in detail &&
+          typeof (detail as { detail: unknown }).detail === "string"
+            ? (detail as { detail: string }).detail
+            : "";
+
+        const projectMissing =
+          detailStr.includes("not found") ||
+          detailStr.includes("Project not found");
+
+        if (projectMissing) {
+          return NextResponse.json(
+            emptyAgentMetrics(
+              agent,
+              range.window,
+              "No Phoenix traces yet for this agent. Use the agent in the main UI (chat or A2A) once; Phoenix creates project '" +
+                agent +
+                "' on first span.",
+            ),
+          );
+        }
+
+        return NextResponse.json(
+          {
+            error: "Agent or Phoenix project not found",
+            agent,
+            detail,
+          },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json(
+        { error: err.message, agent, detail },
+        { status: err.status >= 400 && err.status < 600 ? err.status : 502 },
+      );
+    }
+
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message, agent }, { status: 500 });
+  }
+}

--- a/web/metrics-dashboard/app/api/sessions/[sessionId]/route.ts
+++ b/web/metrics-dashboard/app/api/sessions/[sessionId]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { getBearerAuthForNasiko, unauthorizedResponse } from "@/lib/auth";
+import { computeStartTimeIso, parseMetricsWindow } from "@/lib/metrics";
+import {
+  fetchNasikoAgentStats,
+  fetchNasikoSessionDetails,
+  NasikoApiError,
+} from "@/lib/nasiko";
+import { extractSessionTraces } from "@/lib/sessions";
+
+type RouteContext = { params: Promise<{ sessionId: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  const authorization = getBearerAuthForNasiko(request);
+  if (!authorization) {
+    return unauthorizedResponse();
+  }
+
+  const { sessionId } = await context.params;
+  const { searchParams } = new URL(request.url);
+  const agent = searchParams.get("agent")?.trim();
+  if (!agent) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: agent" },
+      { status: 400 },
+    );
+  }
+
+  const windowResult = parseMetricsWindow(searchParams.get("window"));
+  if ("error" in windowResult) {
+    return NextResponse.json({ error: windowResult.error }, { status: 400 });
+  }
+
+  try {
+    const startTimeIso = computeStartTimeIso(windowResult.hours);
+    const [sessionPayload, statsResponse] = await Promise.all([
+      fetchNasikoSessionDetails(authorization, sessionId),
+      fetchNasikoAgentStats(authorization, agent, startTimeIso).catch(() => null),
+    ]);
+
+    const payload = sessionPayload as Record<string, unknown>;
+    const data = (payload.data ?? payload) as Record<string, unknown>;
+    const session = (data.session ?? data) as Record<string, unknown>;
+    const tracesRaw = (session.traces ?? []) as Array<Record<string, unknown>>;
+    const traces = extractSessionTraces(tracesRaw);
+    const projectId =
+      (statsResponse?.data?.project?.id as string | undefined) ?? null;
+
+    return NextResponse.json({
+      session_id: sessionId,
+      num_traces: (session.num_traces as number | undefined) ?? traces.length,
+      traces,
+      project_id: projectId,
+    });
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      return NextResponse.json(
+        { error: err.message, session_id: sessionId, detail: err.body },
+        { status: err.status >= 400 && err.status < 600 ? err.status : 502 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message, session_id: sessionId }, { status: 500 });
+  }
+}

--- a/web/metrics-dashboard/app/api/sessions/route.ts
+++ b/web/metrics-dashboard/app/api/sessions/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { getBearerAuthForNasiko, unauthorizedResponse } from "@/lib/auth";
+import { filterNasikoSessionsInRange } from "@/lib/session-filters";
+import { parseTimeRangeQuery } from "@/lib/time-range";
+import { fetchNasikoObservabilitySessions, NasikoApiError } from "@/lib/nasiko";
+import { normalizeSessions } from "@/lib/sessions";
+
+export async function GET(request: Request) {
+  const authorization = getBearerAuthForNasiko(request);
+  if (!authorization) {
+    return unauthorizedResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const agent = searchParams.get("agent")?.trim();
+  if (!agent) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: agent" },
+      { status: 400 },
+    );
+  }
+
+  const rangeResult = parseTimeRangeQuery(searchParams);
+  if ("error" in rangeResult) {
+    return NextResponse.json({ error: rangeResult.error }, { status: 400 });
+  }
+  const range = rangeResult;
+
+  try {
+    const sessionsResponse = await fetchNasikoObservabilitySessions(
+      authorization,
+      range.startTimeIso,
+    );
+    const sessions = normalizeSessions(
+      filterNasikoSessionsInRange(
+        sessionsResponse.data?.sessions ?? [],
+        range.startMs,
+        range.endMs,
+      ),
+      agent,
+    );
+
+    return NextResponse.json({
+      agent,
+      window: range.window,
+      start_time: range.startTimeIso,
+      end_time: range.endTimeIso,
+      sessions,
+    });
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      return NextResponse.json(
+        { error: err.message, agent, detail: err.body },
+        { status: err.status >= 400 && err.status < 600 ? err.status : 502 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message, agent }, { status: 500 });
+  }
+}

--- a/web/metrics-dashboard/app/api/traces/route.ts
+++ b/web/metrics-dashboard/app/api/traces/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { getBearerAuthForNasiko, unauthorizedResponse } from "@/lib/auth";
+import { computeStartTimeIso, parseMetricsWindow } from "@/lib/metrics";
+import {
+  fetchNasikoAgentStats,
+  fetchNasikoTraceDetails,
+  NasikoApiError,
+} from "@/lib/nasiko";
+import { parseTraceSpans } from "@/lib/trace-graph";
+import { spansToPipelineGraph } from "@/lib/trace-pipeline";
+
+export async function GET(request: Request) {
+  const authorization = getBearerAuthForNasiko(request);
+  if (!authorization) {
+    return unauthorizedResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const agent = searchParams.get("agent")?.trim();
+  const traceId = searchParams.get("traceId")?.trim();
+  const projectIdParam = searchParams.get("projectId")?.trim();
+
+  if (!agent || !traceId) {
+    return NextResponse.json(
+      { error: "Missing required query parameters: agent, traceId" },
+      { status: 400 },
+    );
+  }
+
+  const windowResult = parseMetricsWindow(searchParams.get("window"));
+  if ("error" in windowResult) {
+    return NextResponse.json({ error: windowResult.error }, { status: 400 });
+  }
+
+  try {
+    let projectId = projectIdParam ?? null;
+    if (!projectId) {
+      const startTimeIso = computeStartTimeIso(windowResult.hours);
+      const stats = await fetchNasikoAgentStats(authorization, agent, startTimeIso);
+      projectId = stats.data?.project?.id ?? null;
+    }
+
+    if (!projectId) {
+      return NextResponse.json(
+        {
+          error: "Phoenix project id not found for agent",
+          agent,
+          detail: "Deploy agent and generate traces first.",
+        },
+        { status: 404 },
+      );
+    }
+
+    const tracePayload = await fetchNasikoTraceDetails(
+      authorization,
+      projectId,
+      traceId,
+    );
+
+    const roots = parseTraceSpans(tracePayload);
+    const userPreview = searchParams.get("userPreview")?.trim() || null;
+    const { nodes, edges, truncated } = spansToPipelineGraph(roots, {
+      userPreview,
+    });
+
+    const payload = tracePayload as Record<string, unknown>;
+    const data = (payload.data ?? payload) as Record<string, unknown>;
+    const trace = (data.trace ?? {}) as Record<string, unknown>;
+
+    return NextResponse.json({
+      agent,
+      trace_id: traceId,
+      latency_ms:
+        typeof trace.latency_ms === "number" ? trace.latency_ms : null,
+      num_spans: nodes.length,
+      total_spans:
+        typeof trace.num_spans === "number" ? trace.num_spans : nodes.length,
+      nodes,
+      edges,
+      truncated,
+    });
+  } catch (err) {
+    if (err instanceof NasikoApiError) {
+      return NextResponse.json(
+        { error: err.message, agent, traceId, detail: err.body },
+        { status: err.status >= 400 && err.status < 600 ? err.status : 502 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message, agent, traceId }, { status: 500 });
+  }
+}

--- a/web/metrics-dashboard/app/globals.css
+++ b/web/metrics-dashboard/app/globals.css
@@ -1,0 +1,66 @@
+:root {
+  --bg: #0f1419;
+  --surface: #1a2332;
+  --text: #e8eef4;
+  --muted: #8b9cb3;
+  --accent: #3b82f6;
+  --border: #2d3a4d;
+  --ok: #22c55e;
+  --bad: #ef4444;
+  --bad-soft: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  max-width: 100vw;
+  min-height: 100vh;
+}
+
+body {
+  color: var(--text);
+  background: var(--bg);
+  font-family:
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+}
+
+button {
+  font: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+code {
+  font-size: 0.85em;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}

--- a/web/metrics-dashboard/app/layout.tsx
+++ b/web/metrics-dashboard/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Agent Metrics | Nasiko",
+  description: "Per-agent performance metrics for the Nasiko Titan Builder Challenge",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/web/metrics-dashboard/app/logs/page.tsx
+++ b/web/metrics-dashboard/app/logs/page.tsx
@@ -1,0 +1,11 @@
+import { LogsView } from "@/components/LogsView";
+
+export const metadata = {
+  title: "Platform Logs | Nasiko",
+  description:
+    "Activity log for Nasiko — recent platform events synthesized from observability data.",
+};
+
+export default function LogsPage() {
+  return <LogsView />;
+}

--- a/web/metrics-dashboard/app/page.tsx
+++ b/web/metrics-dashboard/app/page.tsx
@@ -1,0 +1,5 @@
+import { MetricsDashboard } from "@/components/MetricsDashboard";
+
+export default function MetricsPage() {
+  return <MetricsDashboard />;
+}

--- a/web/metrics-dashboard/components/AgentsOverviewTable.tsx
+++ b/web/metrics-dashboard/components/AgentsOverviewTable.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  formatCostUsd,
+  formatCount,
+  formatLatencyMs,
+  formatPercent,
+} from "@/lib/format";
+import type { FleetAgentRow } from "@/lib/fleet-rollup";
+
+type Props = {
+  rows: FleetAgentRow[];
+  loading?: boolean;
+  onSelectAgent: (agentId: string) => void;
+};
+
+export function AgentsOverviewTable({ rows, loading, onSelectAgent }: Props) {
+  if (loading) {
+    return (
+      <section className="panel">
+        <h2 className="panel__title">By agent</h2>
+        <p className="panel__hint">Loading…</p>
+      </section>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <section className="panel">
+        <h2 className="panel__title">By agent</h2>
+        <p className="panel__hint">Deploy agents in the main app to see them here.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel" aria-labelledby="agents-overview-heading">
+      <h2 id="agents-overview-heading" className="panel__title">
+        By agent
+      </h2>
+      <p className="panel__hint">
+        Compare each agent side by side. Open one for charts and recent requests.
+      </p>
+      <div className="table-wrap">
+        <table className="data-table data-table--overview">
+          <thead>
+            <tr>
+              <th scope="col">Agent</th>
+              <th scope="col">Response time</th>
+              <th scope="col">Successful</th>
+              <th scope="col">Failed</th>
+              <th scope="col">Availability</th>
+              <th scope="col">Est. cost</th>
+              <th scope="col">
+                <span className="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const m = row.metrics;
+              const noData = m.no_data === true;
+              return (
+                <tr key={row.agentId} data-muted={noData || undefined}>
+                  <td>
+                    <strong>{row.name}</strong>
+                    {noData && (
+                      <span className="table-subtle"> · No traffic yet</span>
+                    )}
+                  </td>
+                  <td>{noData ? "—" : formatLatencyMs(m.avg_latency_ms)}</td>
+                  <td>{noData ? "—" : formatCount(m.success)}</td>
+                  <td>{noData ? "—" : formatCount(m.error)}</td>
+                  <td>{noData ? "—" : formatPercent(m.uptime_pct)}</td>
+                  <td>{noData ? "—" : formatCostUsd(m.source?.cost_usd)}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn btn--sm"
+                      onClick={() => onSelectAgent(row.agentId)}
+                    >
+                      View details
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/web/metrics-dashboard/components/CostSplit.tsx
+++ b/web/metrics-dashboard/components/CostSplit.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { formatCostUsd } from "@/lib/format";
+import type { AgentMetricsResponse } from "@/lib/types";
+
+/**
+ * Tier B — Tiny prompt-vs-completion split inside the "Estimated cost" card.
+ * Renders nothing when neither half is available so the card stays clean.
+ */
+export function CostSplit({
+  breakdown,
+}: {
+  breakdown: AgentMetricsResponse["source"] extends infer S
+    ? S extends { cost_breakdown?: infer B }
+      ? B
+      : never
+    : never;
+}) {
+  if (!breakdown) {
+    return null;
+  }
+  const prompt = breakdown.prompt_usd ?? 0;
+  const completion = breakdown.completion_usd ?? 0;
+  const total = prompt + completion;
+  if (total <= 0) {
+    return null;
+  }
+  const promptPct = (prompt / total) * 100;
+  const completionPct = (completion / total) * 100;
+
+  return (
+    <div className="cost-split" role="img" aria-label="Cost split: prompt vs completion">
+      <div className="cost-split__track" aria-hidden="true">
+        <span
+          className="cost-split__seg cost-split__seg--prompt"
+          style={{ flex: `${promptPct.toFixed(2)} 0 0` }}
+          title={`Prompt · ${formatCostUsd(prompt)} (${promptPct.toFixed(0)}%)`}
+        />
+        <span
+          className="cost-split__seg cost-split__seg--completion"
+          style={{ flex: `${completionPct.toFixed(2)} 0 0` }}
+          title={`Completion · ${formatCostUsd(completion)} (${completionPct.toFixed(0)}%)`}
+        />
+      </div>
+      <div className="cost-split__legend">
+        <span>
+          <span className="legend-swatch cost-split__swatch--prompt" aria-hidden /> Prompt {promptPct.toFixed(0)}%
+        </span>
+        <span>
+          <span className="legend-swatch cost-split__swatch--completion" aria-hidden /> Completion {completionPct.toFixed(0)}%
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/DashboardNav.tsx
+++ b/web/metrics-dashboard/components/DashboardNav.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+export type DashboardView = "fleet" | "agent";
+
+type Props = {
+  view: DashboardView;
+  onChange: (view: DashboardView) => void;
+};
+
+export function DashboardNav({ view, onChange }: Props) {
+  return (
+    <nav className="dashboard-nav" aria-label="Dashboard views">
+      <button
+        type="button"
+        className={`dashboard-nav__btn${view === "fleet" ? " dashboard-nav__btn--active" : ""}`}
+        aria-current={view === "fleet" ? "page" : undefined}
+        onClick={() => onChange("fleet")}
+      >
+        All agents
+      </button>
+      <button
+        type="button"
+        className={`dashboard-nav__btn${view === "agent" ? " dashboard-nav__btn--active" : ""}`}
+        aria-current={view === "agent" ? "page" : undefined}
+        onClick={() => onChange("agent")}
+      >
+        Single agent
+      </button>
+    </nav>
+  );
+}

--- a/web/metrics-dashboard/components/FeedbackBar.tsx
+++ b/web/metrics-dashboard/components/FeedbackBar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * Tier B — Stacked label-distribution bar shown inside the "User feedback"
+ * KPI card. Renders top label fractions (e.g. "thumbs_up 0.82" /
+ * "thumbs_down 0.12" / "neutral 0.06") as a single thin bar with tonal colors
+ * inferred from common label keywords. Falls back to neutral for anything we
+ * can't classify, so a custom rubric ("excellent" / "poor") still renders.
+ */
+
+type LabelEntry = { label: string; fraction: number };
+
+type Props = {
+  labels: LabelEntry[] | null | undefined;
+  /** Max items to render (rest collapse into "Other"). */
+  maxItems?: number;
+};
+
+type Tone = "good" | "bad" | "neutral";
+
+function classify(label: string): Tone {
+  const lower = label.toLowerCase();
+  if (
+    /^(thumbs_?up|up|positive|pos|good|excellent|great|approved|like|yes|correct|ok)$/.test(
+      lower,
+    )
+  ) {
+    return "good";
+  }
+  if (
+    /^(thumbs_?down|down|negative|neg|bad|poor|fail|failed|error|disliked|no|incorrect)$/.test(
+      lower,
+    )
+  ) {
+    return "bad";
+  }
+  return "neutral";
+}
+
+function pretty(label: string): string {
+  return label
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function FeedbackBar({ labels, maxItems = 4 }: Props) {
+  if (!labels || labels.length === 0) {
+    return null;
+  }
+
+  const sum = labels.reduce((s, l) => s + Math.max(0, l.fraction), 0);
+  if (sum <= 0) {
+    return null;
+  }
+
+  const sorted = [...labels].sort((a, b) => b.fraction - a.fraction);
+  const head = sorted.slice(0, maxItems);
+  const rest = sorted.slice(maxItems);
+  const restFraction = rest.reduce((s, l) => s + Math.max(0, l.fraction), 0);
+
+  const segments: Array<LabelEntry & { tone: Tone | "muted" }> = head.map(
+    (l) => ({
+      label: l.label,
+      fraction: Math.max(0, l.fraction) / sum,
+      tone: classify(l.label),
+    }),
+  );
+  if (restFraction > 0) {
+    segments.push({
+      label: "Other",
+      fraction: restFraction / sum,
+      tone: "muted",
+    });
+  }
+
+  return (
+    <div className="feedback-bar" role="img" aria-label="User feedback distribution">
+      <div className="feedback-bar__track" aria-hidden="true">
+        {segments.map((seg, i) => (
+          <span
+            key={`${seg.label}-${i}`}
+            className={`feedback-bar__seg feedback-bar__seg--${seg.tone}`}
+            style={{ flex: `${(seg.fraction * 100).toFixed(2)} 0 0` }}
+            title={`${pretty(seg.label)} · ${(seg.fraction * 100).toFixed(1)}%`}
+          />
+        ))}
+      </div>
+      <ul className="feedback-bar__legend">
+        {segments.slice(0, 3).map((seg) => (
+          <li key={`legend-${seg.label}`}>
+            <span
+              className={`legend-swatch feedback-bar__swatch--${seg.tone}`}
+              aria-hidden="true"
+            />
+            <span className="feedback-bar__label">{pretty(seg.label)}</span>
+            <span className="feedback-bar__pct">
+              {(seg.fraction * 100).toFixed(0)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/KpiCards.tsx
+++ b/web/metrics-dashboard/components/KpiCards.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import {
+  formatCostUsd,
+  formatCount,
+  formatLatencyMs,
+  formatPercent,
+  formatQualityScore,
+  formatSteps,
+} from "@/lib/format";
+import type { AgentMetricsResponse } from "@/lib/types";
+import { CostSplit } from "@/components/CostSplit";
+import { FeedbackBar } from "@/components/FeedbackBar";
+import { LatencySparkline } from "@/components/LatencySparkline";
+
+type Props = {
+  metrics: AgentMetricsResponse | null;
+  loading?: boolean;
+  noData?: boolean;
+};
+
+type Tone = "neutral" | "good" | "bad";
+
+type Item = {
+  key: string;
+  label: string;
+  value: string;
+  hint: string;
+  tone: Tone;
+  extra?: React.ReactNode;
+};
+
+/** Core metrics at a glance — plain language for stakeholders. */
+export function KpiCards({ metrics, loading, noData }: Props) {
+  const showPlaceholders = loading || noData || metrics == null;
+  const placeholder = loading ? "…" : "—";
+
+  const latencyValue = showPlaceholders
+    ? placeholder
+    : formatLatencyMs(metrics?.avg_latency_ms);
+
+  const quality = metrics?.source?.quality;
+  const orchestration = metrics?.source?.orchestration;
+  const costBreakdown = metrics?.source?.cost_breakdown;
+
+  const items: Item[] = [
+    {
+      key: "latency",
+      label: "Typical response time",
+      value: latencyValue,
+      hint: "How long users wait for an answer",
+      tone: "neutral",
+      extra: !showPlaceholders ? (
+        <LatencySparkline
+          series={metrics?.series_24h}
+          ariaLabel={`24-hour response time trend, typical ${latencyValue}`}
+        />
+      ) : null,
+    },
+    {
+      key: "success",
+      label: "Successful requests",
+      value: showPlaceholders ? placeholder : formatCount(metrics?.success),
+      hint: "Completed without errors · last 24 hours",
+      tone: "good",
+    },
+    {
+      key: "errors",
+      label: "Failed requests",
+      value: showPlaceholders ? placeholder : formatCount(metrics?.error),
+      hint: "Something went wrong for the user",
+      tone: (metrics?.error ?? 0) > 0 ? "bad" : "neutral",
+    },
+    {
+      key: "uptime",
+      label: "Availability",
+      value: showPlaceholders ? placeholder : formatPercent(metrics?.uptime_pct),
+      hint: "Agent was up and reachable",
+      tone: "neutral",
+    },
+    {
+      key: "cost",
+      label: "Estimated cost",
+      value: showPlaceholders ? placeholder : formatCostUsd(metrics?.source?.cost_usd),
+      hint: noData ? "No usage data yet" : "AI usage cost · last 24 hours",
+      tone: "neutral",
+      extra: !showPlaceholders && costBreakdown ? (
+        <CostSplit breakdown={costBreakdown} />
+      ) : null,
+    },
+  ];
+
+  // Tier B — render the quality / feedback card only when annotations exist.
+  if (!showPlaceholders && quality && (quality.sample_count > 0 || quality.top_labels.length > 0)) {
+    items.push({
+      key: "quality",
+      label: "User feedback",
+      value:
+        quality.sample_count > 0
+          ? formatQualityScore(quality.mean_score)
+          : quality.top_labels[0]
+            ? `${(quality.top_labels[0].fraction * 100).toFixed(0)}% ${quality.top_labels[0].label}`
+            : "—",
+      hint:
+        quality.sample_count > 0
+          ? `Mean ${quality.primary_annotation ?? "satisfaction"} · ${quality.sample_count} rated sessions`
+          : "Top label across rated sessions",
+      tone:
+        quality.mean_score == null
+          ? "neutral"
+          : quality.mean_score > 0.7 || quality.mean_score >= 4
+            ? "good"
+            : quality.mean_score < 0.4 || quality.mean_score < 2
+              ? "bad"
+              : "neutral",
+      extra: <FeedbackBar labels={quality.top_labels} />,
+    });
+  }
+
+  // Tier B — orchestration depth (avg steps per request) — only show when we have data.
+  if (
+    !showPlaceholders &&
+    orchestration &&
+    orchestration.avg_traces_per_session != null
+  ) {
+    items.push({
+      key: "orchestration",
+      label: "Avg steps per request",
+      value: formatSteps(orchestration.avg_traces_per_session),
+      hint: `${orchestration.total_traces.toLocaleString()} steps across ${orchestration.total_sessions.toLocaleString()} sessions`,
+      tone: "neutral",
+    });
+  }
+
+  return (
+    <div className="kpi-grid" role="list" aria-label="Performance at a glance">
+      {items.map((item) => (
+        <article
+          key={item.key}
+          className="kpi-card"
+          role="listitem"
+          data-tone={item.tone}
+          aria-busy={loading || undefined}
+        >
+          <p className="kpi-card__label">{item.label}</p>
+          <p className="kpi-card__value" aria-label={`${item.label}: ${item.value}`}>
+            {item.value}
+          </p>
+          {item.extra ?? null}
+          <p className="kpi-card__hint">{item.hint}</p>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/LatencyChart.tsx
+++ b/web/metrics-dashboard/components/LatencyChart.tsx
@@ -1,0 +1,8 @@
+// Deprecated — replaced by `TrafficChart` (stacked success/error bars) on the
+// main panel and `LatencySparkline` inside the "Typical response time" KPI card.
+//
+// This file is intentionally empty: kept temporarily because the sandbox where
+// the swap happened could not delete files. Safe to delete on the next manual
+// pass; nothing in the dashboard imports it.
+
+export {};

--- a/web/metrics-dashboard/components/LatencySparkline.tsx
+++ b/web/metrics-dashboard/components/LatencySparkline.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Area, AreaChart, ResponsiveContainer } from "recharts";
+import type { MetricsHourlyPoint } from "@/lib/types";
+
+type Props = {
+  series: MetricsHourlyPoint[] | undefined | null;
+  ariaLabel?: string;
+};
+
+type Row = { i: number; latency_ms: number | null };
+
+/**
+ * Tiny 24-point area chart embedded inside the "Typical response time" KPI card.
+ * No axes, no tooltips — its job is to show whether latency is steady, climbing,
+ * or spiky at a glance. `connectNulls` keeps the line continuous even when an
+ * hour has no traffic.
+ */
+export function LatencySparkline({ series, ariaLabel }: Props) {
+  const points = series ?? [];
+  const data: Row[] = points.map((p, i) => ({ i, latency_ms: p.latency_ms }));
+  const hasPoints = data.some(
+    (d) => d.latency_ms != null && Number.isFinite(d.latency_ms),
+  );
+
+  if (!hasPoints) {
+    return (
+      <div
+        className="sparkline sparkline--empty"
+        role="img"
+        aria-label={ariaLabel ?? "No latency data yet"}
+      >
+        <span aria-hidden>—</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="sparkline"
+      role="img"
+      aria-label={ariaLabel ?? "24-hour latency trend"}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 4, right: 0, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id="sparkline-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent)" stopOpacity={0.45} />
+              <stop offset="100%" stopColor="var(--accent)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            type="monotone"
+            dataKey="latency_ms"
+            stroke="var(--accent)"
+            strokeWidth={1.5}
+            fill="url(#sparkline-fill)"
+            connectNulls
+            isAnimationActive={false}
+            dot={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/LogsTable.tsx
+++ b/web/metrics-dashboard/components/LogsTable.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { formatDateTime, formatLatencyMs, formatShortId } from "@/lib/format";
+import type { LogLevel, SyntheticLogRow } from "@/lib/types";
+
+type Props = {
+  rows: SyntheticLogRow[];
+  loading?: boolean;
+};
+
+const LEVEL_CLASS: Record<LogLevel, string> = {
+  INFO: "log-badge--info",
+  WARNING: "log-badge--warn",
+  ERROR: "log-badge--error",
+};
+
+function LogRow({ row }: { row: SyntheticLogRow }) {
+  const [open, setOpen] = useState(false);
+  const hasDetail =
+    row.detail != null && typeof row.detail === "object" && Object.keys(row.detail).length > 0;
+  return (
+    <>
+      <tr
+        className={hasDetail ? "log-row log-row--clickable" : "log-row"}
+        onClick={hasDetail ? () => setOpen((v) => !v) : undefined}
+        aria-expanded={hasDetail ? open : undefined}
+      >
+        <td className="log-row__time">{formatDateTime(row.ts)}</td>
+        <td>
+          <span className={`log-badge ${LEVEL_CLASS[row.level]}`}>
+            {row.level}
+          </span>
+        </td>
+        <td className="log-row__service">{row.service}</td>
+        <td className="log-row__message">{row.message}</td>
+        <td className="log-row__meta">
+          {row.session_id ? (
+            <code title={row.session_id}>{formatShortId(row.session_id)}</code>
+          ) : (
+            "—"
+          )}
+        </td>
+        <td className="log-row__meta">
+          {row.latency_ms != null ? formatLatencyMs(row.latency_ms) : "—"}
+        </td>
+      </tr>
+      {hasDetail && open && (
+        <tr className="log-row__detail">
+          <td colSpan={6}>
+            <pre>{JSON.stringify(row.detail, null, 2)}</pre>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export function LogsTable({ rows, loading }: Props) {
+  return (
+    <section
+      className="panel logs-panel"
+      aria-busy={loading || undefined}
+      aria-label="Recent platform logs"
+    >
+      <div className="logs-table-wrap">
+        <table className="logs-table">
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Level</th>
+              <th scope="col">Service</th>
+              <th scope="col">Message</th>
+              <th scope="col">Session</th>
+              <th scope="col">Latency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <LogRow key={row.id} row={row} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/web/metrics-dashboard/components/LogsToolbar.tsx
+++ b/web/metrics-dashboard/components/LogsToolbar.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import type { LogLevel } from "@/lib/types";
+
+type LoadState = "idle" | "loading" | "ready" | "error" | "auth";
+
+type Props = {
+  activeLevels: Set<LogLevel>;
+  levelCounts: Record<LogLevel, number>;
+  onToggleLevel: (level: LogLevel) => void;
+  onSelectAll: () => void;
+  search: string;
+  onSearchChange: (next: string) => void;
+  isLoading: boolean;
+  autoRefresh: boolean;
+  onAutoRefreshChange: (next: boolean) => void;
+  onRefresh: () => void;
+  status: LoadState;
+  relativeLabel: string;
+  absoluteLabel: string;
+  lastUpdated: Date | null;
+};
+
+const LEVELS: { level: LogLevel; label: string; cls: string }[] = [
+  { level: "INFO", label: "Info", cls: "log-chip--info" },
+  { level: "WARNING", label: "Warning", cls: "log-chip--warn" },
+  { level: "ERROR", label: "Error", cls: "log-chip--error" },
+];
+
+export function LogsToolbar({
+  activeLevels,
+  levelCounts,
+  onToggleLevel,
+  onSelectAll,
+  search,
+  onSearchChange,
+  isLoading,
+  autoRefresh,
+  onAutoRefreshChange,
+  onRefresh,
+  status,
+  relativeLabel,
+  absoluteLabel,
+  lastUpdated,
+}: Props) {
+  const allActive = LEVELS.every((l) => activeLevels.has(l.level));
+  return (
+    <div className="toolbar" role="toolbar" aria-label="Log filters">
+      <div className="log-filter" role="group" aria-label="Log level filter">
+        <button
+          type="button"
+          className={`log-chip log-chip--all ${allActive ? "log-chip--active" : ""}`}
+          onClick={onSelectAll}
+          aria-pressed={allActive}
+        >
+          All
+        </button>
+        {LEVELS.map((l) => {
+          const isActive = activeLevels.has(l.level);
+          return (
+            <button
+              key={l.level}
+              type="button"
+              className={`log-chip ${l.cls} ${isActive ? "log-chip--active" : ""}`}
+              onClick={() => onToggleLevel(l.level)}
+              aria-pressed={isActive}
+            >
+              {l.label}
+              <span className="log-chip__count" aria-hidden="true">
+                {levelCounts[l.level].toLocaleString()}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="field" style={{ minWidth: 220, flex: "1 1 240px" }}>
+        <label htmlFor="logs-search">Search</label>
+        <input
+          id="logs-search"
+          type="search"
+          className="logs-search"
+          placeholder="Filter by message, agent, or session…"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </div>
+
+      <div className="toolbar__actions">
+        <button
+          type="button"
+          className="btn btn--primary"
+          disabled={isLoading}
+          onClick={onRefresh}
+          aria-label={isLoading ? "Refreshing logs" : "Refresh logs now"}
+        >
+          {isLoading ? "Refreshing…" : "Refresh"}
+        </button>
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={autoRefresh}
+            onChange={(e) => onAutoRefreshChange(e.target.checked)}
+            aria-describedby="logs-auto-refresh-hint"
+          />
+          <span>Auto refresh</span>
+        </label>
+        <span id="logs-auto-refresh-hint" className="sr-only">
+          When enabled, logs reload every 60 seconds.
+        </span>
+      </div>
+
+      <div
+        className="status-pill"
+        aria-live="polite"
+        data-state={status}
+        title={lastUpdated ? `Last updated ${lastUpdated.toLocaleString()}` : "No data yet"}
+      >
+        <span
+          className={`status-pill__dot status-pill__dot--${status}`}
+          aria-hidden="true"
+        />
+        <span className="status-pill__text">
+          {isLoading
+            ? "Loading…"
+            : lastUpdated
+              ? `Updated ${relativeLabel}`
+              : "Awaiting data"}
+        </span>
+        {lastUpdated && (
+          <span className="status-pill__abs" aria-hidden="true">
+            · {absoluteLabel}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/LogsView.tsx
+++ b/web/metrics-dashboard/components/LogsView.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { fetchLogs, MetricsApiError } from "@/lib/api-client";
+import {
+  clearDevAccessToken,
+  getAccessTokenFromStorage,
+  setDevAccessToken,
+} from "@/lib/auth-client";
+import { countByLevel, filterLogs } from "@/lib/logs";
+import type { LogLevel, LogsResponse, SyntheticLogRow } from "@/lib/types";
+import { LogsTable } from "@/components/LogsTable";
+import { LogsToolbar } from "@/components/LogsToolbar";
+import "./metrics-dashboard.css";
+
+const NASIKO_APP_URL =
+  process.env.NEXT_PUBLIC_NASIKO_APP_URL ?? "http://localhost:9100/app/";
+
+const AUTO_REFRESH_MS = 60_000;
+
+type LoadState = "idle" | "loading" | "ready" | "error" | "auth";
+
+function formatRelative(date: Date | null, now: Date): string {
+  if (!date) return "never";
+  const deltaSec = Math.max(0, Math.round((now.getTime() - date.getTime()) / 1000));
+  if (deltaSec < 5) return "just now";
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const min = Math.round(deltaSec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  return `${hr}h ago`;
+}
+
+const ALL_LEVELS: LogLevel[] = ["INFO", "WARNING", "ERROR"];
+
+export function LogsView() {
+  const [token, setToken] = useState<string | null>(null);
+  const [data, setData] = useState<LogsResponse | null>(null);
+  const [state, setState] = useState<LoadState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [devTokenInput, setDevTokenInput] = useState("");
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [now, setNow] = useState(() => new Date());
+
+  // Filters
+  const [activeLevels, setActiveLevels] = useState<Set<LogLevel>>(
+    () => new Set<LogLevel>(ALL_LEVELS),
+  );
+  const [search, setSearch] = useState("");
+
+  const refreshRef = useRef<() => void>(() => {});
+
+  const resolveToken = useCallback(() => {
+    const t = getAccessTokenFromStorage();
+    setToken(t);
+    return t;
+  }, []);
+
+  useEffect(() => {
+    resolveToken();
+  }, [resolveToken]);
+
+  const refresh = useCallback(async () => {
+    const accessToken = resolveToken();
+    if (!accessToken) {
+      setState("auth");
+      return;
+    }
+    setState("loading");
+    setErrorMessage(null);
+    try {
+      const body = await fetchLogs(accessToken, "24h");
+      setData(body);
+      setLastUpdated(new Date());
+      setState("ready");
+    } catch (err) {
+      if (err instanceof MetricsApiError && err.status === 401) {
+        setState("auth");
+        setErrorMessage("Session expired. Sign in again or paste a new token.");
+        return;
+      }
+      setState("error");
+      setErrorMessage(err instanceof Error ? err.message : "Failed to load logs");
+    }
+  }, [resolveToken]);
+
+  useEffect(() => {
+    refreshRef.current = () => {
+      void refresh();
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!token) {
+      setState("auth");
+      return;
+    }
+    void refresh();
+  }, [token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const id = window.setInterval(() => refreshRef.current(), AUTO_REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, [autoRefresh]);
+
+  const handleDevTokenSave = () => {
+    if (!devTokenInput.trim()) return;
+    setDevAccessToken(devTokenInput.trim());
+    setToken(devTokenInput.trim());
+    setState("loading");
+  };
+
+  const handleDevTokenClear = () => {
+    clearDevAccessToken();
+    setDevTokenInput("");
+    setToken(null);
+    setState("auth");
+  };
+
+  const toggleLevel = useCallback((level: LogLevel) => {
+    setActiveLevels((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) {
+        next.delete(level);
+        if (next.size === 0) {
+          // Don't allow zero-state filter — re-enable all.
+          for (const l of ALL_LEVELS) next.add(l);
+        }
+      } else {
+        next.add(level);
+      }
+      return next;
+    });
+  }, []);
+
+  const setAllLevels = useCallback(() => {
+    setActiveLevels(new Set<LogLevel>(ALL_LEVELS));
+  }, []);
+
+  const allLogs: SyntheticLogRow[] = useMemo(
+    () => data?.logs ?? [],
+    [data],
+  );
+  const levelCounts = useMemo(() => countByLevel(allLogs), [allLogs]);
+  const filtered = useMemo(
+    () => filterLogs(allLogs, { levels: activeLevels, search }),
+    [allLogs, activeLevels, search],
+  );
+
+  const isLoading = state === "loading";
+  const relativeLabel = formatRelative(lastUpdated, now);
+  const absoluteLabel = lastUpdated ? lastUpdated.toLocaleTimeString() : "—";
+
+  if (state === "auth") {
+    return (
+      <main id="main" className="dashboard" aria-labelledby="logs-title">
+        <header className="dashboard__header">
+          <p className="dashboard__eyebrow">Nasiko · Titan Builder Challenge</p>
+          <h1 id="logs-title" className="dashboard__title">Platform Logs</h1>
+        </header>
+        <div className="state-box" role="region" aria-labelledby="auth-heading">
+          <h2 id="auth-heading">Sign in required</h2>
+          <p>
+            Open the main Nasiko app on the <strong>same host</strong> as this page
+            so your session token is available, or paste a JWT for local dev.
+          </p>
+          <p>
+            <a href={NASIKO_APP_URL}>Sign in at {NASIKO_APP_URL}</a>
+          </p>
+          <div className="auth-panel">
+            <label htmlFor="dev-token">Dev token (local port 3003 only)</label>
+            <input
+              id="dev-token"
+              type="password"
+              autoComplete="off"
+              placeholder="Paste access_token from nasiko-credentials-*.json"
+              value={devTokenInput}
+              onChange={(e) => setDevTokenInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleDevTokenSave();
+              }}
+            />
+            <small>
+              From DevTools → Application → Local Storage on{" "}
+              <code>localhost:9100</code>, key <code>nasiko-credentials-…</code>,
+              field <code>access_token</code>.
+            </small>
+            <div className="auth-panel__actions">
+              <button
+                type="button"
+                className="btn btn--primary"
+                onClick={handleDevTokenSave}
+                disabled={!devTokenInput.trim()}
+              >
+                Use token
+              </button>
+              <button type="button" className="btn" onClick={handleDevTokenClear}>
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <a href="#main" className="skip-link">Skip to logs</a>
+      <main id="main" className="dashboard" aria-labelledby="logs-title">
+        <header className="dashboard__header">
+          <p className="dashboard__eyebrow">Nasiko · Titan Builder Challenge</p>
+          <h1 id="logs-title" className="dashboard__title">Platform Logs</h1>
+          <p className="dashboard__subtitle">
+            Recent activity across your agents and the platform — last 24 hours.
+            Each row is synthesized from observability sessions or the agent
+            registry; no separate log pipeline required.
+          </p>
+        </header>
+
+        <nav className="dashboard-nav" aria-label="Section navigation">
+          <Link href="/" className="dashboard-nav__btn">
+            ← Agent metrics
+          </Link>
+          <span
+            className="dashboard-nav__btn dashboard-nav__btn--active"
+            aria-current="page"
+          >
+            Platform logs
+          </span>
+        </nav>
+
+        <LogsToolbar
+          activeLevels={activeLevels}
+          levelCounts={levelCounts}
+          onToggleLevel={toggleLevel}
+          onSelectAll={setAllLevels}
+          search={search}
+          onSearchChange={setSearch}
+          isLoading={isLoading}
+          autoRefresh={autoRefresh}
+          onAutoRefreshChange={setAutoRefresh}
+          onRefresh={() => void refresh()}
+          status={state}
+          relativeLabel={relativeLabel}
+          absoluteLabel={absoluteLabel}
+          lastUpdated={lastUpdated}
+        />
+
+        {state === "error" && errorMessage && (
+          <div
+            className="state-box state-box--error"
+            role="alert"
+            aria-live="assertive"
+            style={{ marginBottom: "1rem" }}
+          >
+            <h2>Could not load logs</h2>
+            <p>{errorMessage}</p>
+            <button type="button" className="btn btn--primary" onClick={() => void refresh()}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {state === "ready" && filtered.length === 0 && allLogs.length === 0 && (
+          <div className="state-box" role="status" aria-live="polite">
+            <h2>No activity yet</h2>
+            <p>
+              Once people start using your agents, every request and registry
+              event will show up here.
+            </p>
+            <p>
+              <a className="btn btn--primary" href={NASIKO_APP_URL}>
+                Open main app
+              </a>
+            </p>
+          </div>
+        )}
+
+        {state === "ready" && filtered.length === 0 && allLogs.length > 0 && (
+          <div className="state-box" role="status" aria-live="polite">
+            <h2>No logs match this filter</h2>
+            <p>
+              {allLogs.length.toLocaleString()} log{allLogs.length === 1 ? "" : "s"} in
+              the window. Try a different level or clear the search.
+            </p>
+            <button type="button" className="btn" onClick={setAllLevels}>
+              Reset filters
+            </button>
+          </div>
+        )}
+
+        {filtered.length > 0 && (
+          <LogsTable rows={filtered} loading={isLoading} />
+        )}
+
+        <p className="footer-meta" aria-live="polite">
+          {data
+            ? `${filtered.length.toLocaleString()} of ${data.total.toLocaleString()} logs · sessions ${data.source_counts.sessions.toLocaleString()} · registry ${data.source_counts.registry.toLocaleString()}`
+            : "—"}
+          {lastUpdated && ` · Last updated ${lastUpdated.toLocaleString()}`}
+        </p>
+      </main>
+    </>
+  );
+}

--- a/web/metrics-dashboard/components/MetricsDashboard.tsx
+++ b/web/metrics-dashboard/components/MetricsDashboard.tsx
@@ -1,0 +1,711 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  fetchAgentMetrics,
+  fetchAgentSessions,
+  fetchAgents,
+  fetchSessionDetail,
+  fetchTraceGraph,
+  MetricsApiError,
+} from "@/lib/api-client";
+import {
+  clearDevAccessToken,
+  getAccessTokenFromStorage,
+  setDevAccessToken,
+} from "@/lib/auth-client";
+import { pickPrimaryTrace } from "@/lib/sessions";
+import type {
+  AgentMetricsResponse,
+  MetricsAgentOption,
+  MetricsSessionRow,
+  TraceDetailResponse,
+} from "@/lib/types";
+import { AgentsOverviewTable } from "@/components/AgentsOverviewTable";
+import { DashboardNav, type DashboardView } from "@/components/DashboardNav";
+import { KpiCards } from "@/components/KpiCards";
+import { TrafficChart } from "@/components/TrafficChart";
+import { MetricsTimeRangeBar } from "@/components/MetricsTimeRangeBar";
+import { RequestTracesWorkspace } from "@/components/RequestTracesWorkspace";
+import { aggregateFleetMetrics, type FleetAgentRow } from "@/lib/fleet-rollup";
+import { defaultTimeRange, type MetricsTimeRange } from "@/lib/time-range";
+import "./metrics-dashboard.css";
+
+const NASIKO_APP_URL =
+  process.env.NEXT_PUBLIC_NASIKO_APP_URL ?? "http://localhost:9100/app/";
+
+const AUTO_REFRESH_MS = 60_000;
+
+type LoadState = "idle" | "loading" | "ready" | "error" | "auth";
+
+function formatRelative(date: Date | null, now: Date): string {
+  if (!date) return "never";
+  const deltaSec = Math.max(0, Math.round((now.getTime() - date.getTime()) / 1000));
+  if (deltaSec < 5) return "just now";
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  const min = Math.round(deltaSec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  return `${hr}h ago`;
+}
+
+export function MetricsDashboard() {
+  const [token, setToken] = useState<string | null>(null);
+  const [agents, setAgents] = useState<MetricsAgentOption[]>([]);
+  const [selectedAgentId, setSelectedAgentId] = useState<string>("");
+  const [metrics, setMetrics] = useState<AgentMetricsResponse | null>(null);
+  const [state, setState] = useState<LoadState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [devTokenInput, setDevTokenInput] = useState("");
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [now, setNow] = useState(() => new Date());
+  const [sessions, setSessions] = useState<MetricsSessionRow[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [trace, setTrace] = useState<TraceDetailResponse | null>(null);
+  const [traceLoading, setTraceLoading] = useState(false);
+  const [traceError, setTraceError] = useState<string | null>(null);
+  const [traceLoadingSessionId, setTraceLoadingSessionId] = useState<string | null>(
+    null,
+  );
+  const [dashboardView, setDashboardView] = useState<DashboardView>("agent");
+  const [fleetMetrics, setFleetMetrics] = useState<AgentMetricsResponse | null>(
+    null,
+  );
+  const [fleetRows, setFleetRows] = useState<FleetAgentRow[]>([]);
+  const [timeRange, setTimeRange] = useState<MetricsTimeRange>(() =>
+    defaultTimeRange(),
+  );
+
+  const refreshRef = useRef<() => void>(() => {});
+
+  const resolveToken = useCallback(() => {
+    const t = getAccessTokenFromStorage();
+    setToken(t);
+    return t;
+  }, []);
+
+  useEffect(() => {
+    resolveToken();
+  }, [resolveToken]);
+
+  const loadAgents = useCallback(async (accessToken: string) => {
+    const list = await fetchAgents(accessToken);
+    setAgents(list);
+    if (list.length > 0) {
+      setSelectedAgentId((prev) =>
+        prev && list.some((a) => a.agentId === prev) ? prev : list[0].agentId,
+      );
+    }
+    return list;
+  }, []);
+
+  const loadSessions = useCallback(
+    async (
+      accessToken: string,
+      agentId: string,
+      range: MetricsTimeRange,
+    ) => {
+      if (!agentId) {
+        setSessions([]);
+        return;
+      }
+      setSessionsLoading(true);
+      try {
+        const data = await fetchAgentSessions(accessToken, agentId, range);
+        setSessions(data.sessions);
+      } catch {
+        setSessions([]);
+      } finally {
+        setSessionsLoading(false);
+      }
+    },
+    [],
+  );
+
+  const loadMetrics = useCallback(
+    async (
+      accessToken: string,
+      agentId: string,
+      range: MetricsTimeRange,
+    ) => {
+      if (!agentId) {
+        setMetrics(null);
+        return;
+      }
+      const data = await fetchAgentMetrics(accessToken, agentId, range);
+      setMetrics(data);
+      setLastUpdated(new Date());
+      await loadSessions(accessToken, agentId, range);
+    },
+    [loadSessions],
+  );
+
+  const handleViewTrace = useCallback(
+    async (sessionId: string) => {
+      const accessToken = resolveToken();
+      if (!accessToken || !selectedAgentId) {
+        return;
+      }
+      setSelectedSessionId(sessionId);
+      setTraceLoading(true);
+      setTraceLoadingSessionId(sessionId);
+      setTraceError(null);
+      setTrace(null);
+      try {
+        const session = await fetchSessionDetail(
+          accessToken,
+          selectedAgentId,
+          sessionId,
+        );
+        const primary = pickPrimaryTrace(session.traces);
+        if (!primary?.trace_id) {
+          setTraceError("No traces found for this session.");
+          return;
+        }
+        const preview =
+          sessions.find((s) => s.session_id === sessionId)?.preview ?? null;
+        const graph = await fetchTraceGraph(
+          accessToken,
+          selectedAgentId,
+          primary.trace_id,
+          session.project_id ?? metrics?.source?.project_id,
+          "24h",
+          preview,
+        );
+        setTrace(graph);
+      } catch (err) {
+        setTraceError(
+          err instanceof Error ? err.message : "Failed to load trace graph",
+        );
+      } finally {
+        setTraceLoading(false);
+        setTraceLoadingSessionId(null);
+      }
+    },
+    [metrics?.source?.project_id, resolveToken, selectedAgentId, sessions],
+  );
+
+  const loadMetricsForAgent = useCallback(
+    async (accessToken: string, agentId: string) => {
+      setState("loading");
+      setErrorMessage(null);
+      try {
+        await loadMetrics(accessToken, agentId, timeRange);
+        setState("ready");
+      } catch (err) {
+        if (err instanceof MetricsApiError && err.status === 401) {
+          setState("auth");
+          setErrorMessage("Session expired. Sign in again or paste a new token.");
+          return;
+        }
+        setState("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Failed to load metrics",
+        );
+      }
+    },
+    [loadMetrics, timeRange],
+  );
+
+  const loadFleetMetrics = useCallback(
+    async (
+      accessToken: string,
+      agentList: MetricsAgentOption[],
+      range: MetricsTimeRange,
+    ) => {
+      if (agentList.length === 0) {
+        setFleetMetrics(null);
+        setFleetRows([]);
+        setLastUpdated(new Date());
+        return;
+      }
+      const results = await Promise.all(
+        agentList.map((agent) =>
+          fetchAgentMetrics(accessToken, agent.agentId, range),
+        ),
+      );
+      const { aggregated, rows } = aggregateFleetMetrics(
+        agentList,
+        results,
+        range.window,
+      );
+      setFleetMetrics(aggregated);
+      setFleetRows(rows);
+      setLastUpdated(new Date());
+    },
+    [],
+  );
+
+  const loadFleetForView = useCallback(
+    async (accessToken: string) => {
+      setState("loading");
+      setErrorMessage(null);
+      try {
+        const list = await loadAgents(accessToken);
+        await loadFleetMetrics(accessToken, list, timeRange);
+        setState("ready");
+      } catch (err) {
+        if (err instanceof MetricsApiError && err.status === 401) {
+          setState("auth");
+          setErrorMessage("Session expired. Sign in again or paste a new token.");
+          return;
+        }
+        setState("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Failed to load fleet metrics",
+        );
+      }
+    },
+    [loadAgents, loadFleetMetrics, timeRange],
+  );
+
+  const handleApplyTimeRange = useCallback(
+    async (range: MetricsTimeRange) => {
+      setTimeRange(range);
+      setSelectedSessionId(null);
+      setTrace(null);
+      setTraceError(null);
+      const accessToken = resolveToken();
+      if (!accessToken) {
+        return;
+      }
+      setState("loading");
+      setErrorMessage(null);
+      try {
+        if (dashboardView === "fleet") {
+          const list =
+            agents.length > 0 ? agents : await loadAgents(accessToken);
+          await loadFleetMetrics(accessToken, list, range);
+        } else if (selectedAgentId) {
+          await loadMetrics(accessToken, selectedAgentId, range);
+        }
+        setState("ready");
+      } catch (err) {
+        if (err instanceof MetricsApiError && err.status === 401) {
+          setState("auth");
+          setErrorMessage("Session expired. Sign in again or paste a new token.");
+          return;
+        }
+        setState("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Failed to load data",
+        );
+      }
+    },
+    [
+      agents,
+      dashboardView,
+      loadAgents,
+      loadFleetMetrics,
+      loadMetrics,
+      resolveToken,
+      selectedAgentId,
+    ],
+  );
+
+  const handleDashboardViewChange = useCallback(
+    (view: DashboardView) => {
+      setDashboardView(view);
+      const accessToken = resolveToken();
+      if (!accessToken) {
+        return;
+      }
+      if (view === "fleet") {
+        void loadFleetForView(accessToken);
+      } else if (selectedAgentId) {
+        void loadMetricsForAgent(accessToken, selectedAgentId);
+      }
+    },
+    [
+      loadFleetForView,
+      loadMetricsForAgent,
+      resolveToken,
+      selectedAgentId,
+    ],
+  );
+
+  const handleDrillToAgent = useCallback(
+    (agentId: string) => {
+      setSelectedAgentId(agentId);
+      setSelectedSessionId(null);
+      setTrace(null);
+      setTraceError(null);
+      setDashboardView("agent");
+      const accessToken = resolveToken();
+      if (accessToken) {
+        void loadMetricsForAgent(accessToken, agentId);
+      }
+    },
+    [loadMetricsForAgent, resolveToken],
+  );
+
+  const refresh = useCallback(async () => {
+    const accessToken = resolveToken();
+    if (!accessToken) {
+      setState("auth");
+      return;
+    }
+
+    setState("loading");
+    setErrorMessage(null);
+
+    try {
+      const list = await loadAgents(accessToken);
+
+      if (dashboardView === "fleet") {
+        await loadFleetMetrics(accessToken, list, timeRange);
+        setState("ready");
+        return;
+      }
+
+      const agentId =
+        selectedAgentId && list.some((a) => a.agentId === selectedAgentId)
+          ? selectedAgentId
+          : (list[0]?.agentId ?? "");
+
+      if (!agentId) {
+        setMetrics(null);
+        setState("ready");
+        return;
+      }
+
+      await loadMetrics(accessToken, agentId, timeRange);
+      setState("ready");
+    } catch (err) {
+      if (err instanceof MetricsApiError && err.status === 401) {
+        setState("auth");
+        setErrorMessage("Session expired. Sign in again or paste a new token.");
+        return;
+      }
+      setState("error");
+      setErrorMessage(err instanceof Error ? err.message : "Failed to load data");
+    }
+  }, [
+    dashboardView,
+    loadAgents,
+    loadFleetMetrics,
+    loadMetrics,
+    resolveToken,
+    selectedAgentId,
+    timeRange,
+  ]);
+
+  // Keep a stable ref so the auto-refresh interval doesn't re-bind on every render.
+  useEffect(() => {
+    refreshRef.current = () => {
+      void refresh();
+    };
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!token) {
+      setState("auth");
+      return;
+    }
+    void refresh();
+  }, [token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // "X seconds ago" ticker — independent of fetch cadence; cheap state update.
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  // Auto-refresh interval — opt-in via toolbar toggle.
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const id = window.setInterval(() => refreshRef.current(), AUTO_REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, [autoRefresh]);
+
+  const handleDevTokenSave = () => {
+    if (!devTokenInput.trim()) {
+      return;
+    }
+    setDevAccessToken(devTokenInput.trim());
+    setToken(devTokenInput.trim());
+    setState("loading");
+  };
+
+  const handleDevTokenClear = () => {
+    clearDevAccessToken();
+    setDevTokenInput("");
+    setToken(null);
+    setState("auth");
+  };
+
+  if (state === "auth") {
+    return (
+      <main id="main" className="dashboard" aria-labelledby="dashboard-title">
+        <header className="dashboard__header">
+          <p className="dashboard__eyebrow">Nasiko · Titan Builder Challenge</p>
+          <h1 id="dashboard-title" className="dashboard__title">Agent Metrics</h1>
+        </header>
+        <div className="state-box" role="region" aria-labelledby="auth-heading">
+          <h2 id="auth-heading">Sign in required</h2>
+          <p>
+            Open the main Nasiko app on the <strong>same host</strong> as this page
+            so your session token is available, or paste a JWT for local dev on port
+            3003.
+          </p>
+          <p>
+            <a href={NASIKO_APP_URL}>Sign in at {NASIKO_APP_URL}</a>
+          </p>
+          <div className="auth-panel">
+            <label htmlFor="dev-token">Dev token (local port 3003 only)</label>
+            <input
+              id="dev-token"
+              type="password"
+              autoComplete="off"
+              placeholder="Paste access_token from nasiko-credentials-*.json"
+              value={devTokenInput}
+              onChange={(e) => setDevTokenInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleDevTokenSave();
+              }}
+            />
+            <small>
+              From DevTools → Application → Local Storage on{" "}
+              <code>localhost:9100</code>, key <code>nasiko-credentials-…</code>, field{" "}
+              <code>access_token</code>.
+            </small>
+            <div className="auth-panel__actions">
+              <button
+                type="button"
+                className="btn btn--primary"
+                onClick={handleDevTokenSave}
+                disabled={!devTokenInput.trim()}
+              >
+                Use token
+              </button>
+              <button type="button" className="btn" onClick={handleDevTokenClear}>
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const isFleetView = dashboardView === "fleet";
+  const displayMetrics = isFleetView ? fleetMetrics : metrics;
+  const emptyAgents = state === "ready" && agents.length === 0;
+  const noData = displayMetrics?.no_data === true;
+  const isLoading = state === "loading";
+  const relativeLabel = formatRelative(lastUpdated, now);
+  const absoluteLabel = lastUpdated ? lastUpdated.toLocaleTimeString() : "—";
+
+  return (
+    <>
+      <a href="#main" className="skip-link">Skip to dashboard</a>
+      <main id="main" className="dashboard" aria-labelledby="dashboard-title">
+        <header className="dashboard__header">
+          <p className="dashboard__eyebrow">Nasiko agent performance</p>
+          <h1 id="dashboard-title" className="dashboard__title">
+            {isFleetView ? "How are your agents doing?" : "How is your agent doing?"}
+          </h1>
+          <p className="dashboard__subtitle">
+            {isFleetView
+              ? "Fleet-wide health for the last 24 hours — totals across every deployed agent."
+              : "A simple health check for the last 24 hours — speed, success rate, and availability."}
+          </p>
+        </header>
+
+        <div className="dashboard-sections">
+          <DashboardNav view={dashboardView} onChange={handleDashboardViewChange} />
+          <Link href="/logs" className="dashboard-nav__link">
+            Platform logs →
+          </Link>
+        </div>
+
+        <div className="toolbar" role="toolbar" aria-label="Dashboard controls">
+          {!isFleetView && (
+          <div className="field">
+            <label htmlFor="agent-select">Agent</label>
+            <select
+              id="agent-select"
+              value={selectedAgentId}
+              disabled={isLoading || agents.length === 0}
+              onChange={(e) => {
+                const id = e.target.value;
+                setSelectedAgentId(id);
+                setSelectedSessionId(null);
+                setTrace(null);
+                setTraceError(null);
+                if (token && id) {
+                  void loadMetricsForAgent(token, id);
+                }
+              }}
+            >
+              {agents.length === 0 ? (
+                <option value="">No agents deployed</option>
+              ) : (
+                agents.map((agent) => (
+                  <option key={agent.agentId} value={agent.agentId}>
+                    {agent.name}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+          )}
+
+          <div className="toolbar__actions">
+            <button
+              type="button"
+              className="btn btn--primary"
+              disabled={isLoading || (!isFleetView && !selectedAgentId)}
+              onClick={() => void refresh()}
+              aria-label={isLoading ? "Refreshing metrics" : "Refresh metrics now"}
+            >
+              {isLoading ? "Refreshing…" : "Refresh"}
+            </button>
+
+            <label className="toggle">
+              <input
+                type="checkbox"
+                checked={autoRefresh}
+                onChange={(e) => setAutoRefresh(e.target.checked)}
+                aria-describedby="auto-refresh-hint"
+              />
+              <span>Auto refresh</span>
+            </label>
+            <span id="auto-refresh-hint" className="sr-only">
+              When enabled, the dashboard reloads every 60 seconds.
+            </span>
+
+            <a className="btn" href={NASIKO_APP_URL}>
+              Main app
+            </a>
+          </div>
+
+          <div
+            className="status-pill"
+            aria-live="polite"
+            data-state={state}
+            title={lastUpdated ? `Last updated ${lastUpdated.toLocaleString()}` : "No data yet"}
+          >
+            <span className={`status-pill__dot status-pill__dot--${state}`} aria-hidden="true" />
+            <span className="status-pill__text">
+              {isLoading
+                ? "Loading…"
+                : lastUpdated
+                  ? `Updated ${relativeLabel}`
+                  : "Awaiting data"}
+            </span>
+            {lastUpdated && (
+              <span className="status-pill__abs" aria-hidden="true">
+                · {absoluteLabel}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {state === "error" && errorMessage && (
+          <div
+            className="state-box state-box--error"
+            role="alert"
+            aria-live="assertive"
+            style={{ marginBottom: "1rem" }}
+          >
+            <h2>Could not load metrics</h2>
+            <p>{errorMessage}</p>
+            <button type="button" className="btn btn--primary" onClick={() => void refresh()}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {emptyAgents && (
+          <div className="state-box" role="status" aria-live="polite" style={{ marginBottom: "1rem" }}>
+            <h2>No agents deployed yet</h2>
+            <p>
+              Once you deploy an agent in the main Nasiko app, it shows up here.
+              The dashboard then tracks its latency, success/error counts, and uptime
+              over the last 24 hours.
+            </p>
+            <p>
+              <a className="btn btn--primary" href={NASIKO_APP_URL}>Open main app</a>
+            </p>
+          </div>
+        )}
+
+        <MetricsTimeRangeBar
+          range={timeRange}
+          onApply={(range) => void handleApplyTimeRange(range)}
+          disabled={isLoading || emptyAgents}
+        />
+
+        {noData && (
+          <div className="state-box" role="status" aria-live="polite" style={{ marginBottom: "1rem" }}>
+            <h2>
+              {isFleetView ? "No activity across agents yet" : "No customer activity yet"}
+            </h2>
+            <p>
+              {displayMetrics?.message ??
+                (isFleetView
+                  ? "Once your agents handle requests, fleet totals and per-agent breakdowns appear here."
+                  : "Once people start using this agent in the main app, you will see speed, success rate, and recent requests here.")}
+            </p>
+            <p>
+              <a className="btn" href={NASIKO_APP_URL}>
+                {isFleetView ? "Open main app" : "Chat with the agent"}
+              </a>
+            </p>
+          </div>
+        )}
+
+        <section aria-labelledby="kpi-heading" aria-busy={isLoading}>
+          <h2 id="kpi-heading" className="section-heading">
+            At a glance
+          </h2>
+          <KpiCards metrics={displayMetrics} loading={isLoading} noData={noData} />
+        </section>
+
+        {isFleetView ? (
+          <AgentsOverviewTable
+            rows={fleetRows}
+            loading={isLoading}
+            onSelectAgent={handleDrillToAgent}
+          />
+        ) : (
+          <>
+            <TrafficChart
+              series={metrics?.series_24h ?? []}
+              loading={isLoading}
+              noData={noData}
+            />
+
+            <RequestTracesWorkspace
+              sessions={sessions}
+              globalRange={timeRange}
+              loading={sessionsLoading || isLoading}
+              selectedSessionId={selectedSessionId}
+              traceLoadingSessionId={traceLoadingSessionId}
+              trace={trace}
+              traceLoading={traceLoading}
+              traceError={traceError}
+              onSelectSession={(id) => void handleViewTrace(id)}
+            />
+          </>
+        )}
+
+        <p className="footer-meta" aria-live="polite">
+          Window {displayMetrics?.window ?? timeRange.window}
+          {isFleetView
+            ? agents.length > 0
+              ? ` · All agents (${agents.length})`
+              : ""
+            : displayMetrics?.agent
+              ? ` · ${displayMetrics.agent}`
+              : ""}
+          {lastUpdated && ` · Last updated ${lastUpdated.toLocaleString()}`}
+        </p>
+      </main>
+    </>
+  );
+}

--- a/web/metrics-dashboard/components/MetricsTimeRangeBar.tsx
+++ b/web/metrics-dashboard/components/MetricsTimeRangeBar.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  buildTimeRange,
+  formatRangeLabel,
+  parseDatetimeLocal,
+  presetTimeRange,
+  toDatetimeLocalValue,
+  type MetricsTimeRange,
+} from "@/lib/time-range";
+
+export type TimeRangeDraft = {
+  fromLocal: string;
+  toLocal: string;
+};
+
+type Props = {
+  range: MetricsTimeRange;
+  onApply: (range: MetricsTimeRange) => void;
+  disabled?: boolean;
+  compact?: boolean;
+  idPrefix?: string;
+};
+
+export function draftFromRange(range: MetricsTimeRange): TimeRangeDraft {
+  return {
+    fromLocal: toDatetimeLocalValue(new Date(range.startMs)),
+    toLocal: toDatetimeLocalValue(new Date(range.endMs)),
+  };
+}
+
+export function rangeFromDraft(draft: TimeRangeDraft): MetricsTimeRange | null {
+  const from = parseDatetimeLocal(draft.fromLocal);
+  const to = parseDatetimeLocal(draft.toLocal);
+  if (!from || !to) {
+    return null;
+  }
+  if (to.getTime() <= from.getTime()) {
+    return null;
+  }
+  return buildTimeRange(from, to);
+}
+
+export function MetricsTimeRangeBar({
+  range,
+  onApply,
+  disabled,
+  compact,
+  idPrefix = "metrics",
+}: Props) {
+  const [draft, setDraft] = useState(() => draftFromRange(range));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft(draftFromRange(range));
+  }, [range.startMs, range.endMs]);
+
+  const applyDraft = () => {
+    const next = rangeFromDraft(draft);
+    if (!next) {
+      setError("End time must be after start time.");
+      return;
+    }
+    setError(null);
+    onApply(next);
+  };
+
+  const applyPreset = (preset: "1h" | "24h" | "7d") => {
+    const next = presetTimeRange(preset);
+    setDraft(draftFromRange(next));
+    setError(null);
+    onApply(next);
+  };
+
+  return (
+    <div
+      className={`time-filter${compact ? " time-filter--compact" : ""}`}
+      role="search"
+      aria-label="Filter by date and time"
+    >
+      {!compact && <p className="time-filter__label">Time range</p>}
+      <div className="time-filter__row">
+        <div className="field field--inline">
+          <label htmlFor={`${idPrefix}-preset`}>Preset</label>
+          <select
+            id={`${idPrefix}-preset`}
+            disabled={disabled}
+            defaultValue=""
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === "1h" || v === "24h" || v === "7d") {
+                applyPreset(v);
+              }
+              e.target.value = "";
+            }}
+          >
+            <option value="" disabled>
+              Quick range…
+            </option>
+            <option value="1h">Last 1 hour</option>
+            <option value="24h">Last 24 hours</option>
+            <option value="7d">Last 7 days</option>
+          </select>
+        </div>
+        <div className="field field--inline">
+          <label htmlFor={`${idPrefix}-from`}>From</label>
+          <input
+            id={`${idPrefix}-from`}
+            type="datetime-local"
+            disabled={disabled}
+            value={draft.fromLocal}
+            onChange={(e) => setDraft((d) => ({ ...d, fromLocal: e.target.value }))}
+          />
+        </div>
+        <div className="field field--inline">
+          <label htmlFor={`${idPrefix}-to`}>To</label>
+          <input
+            id={`${idPrefix}-to`}
+            type="datetime-local"
+            disabled={disabled}
+            value={draft.toLocal}
+            onChange={(e) => setDraft((d) => ({ ...d, toLocal: e.target.value }))}
+          />
+        </div>
+        <button
+          type="button"
+          className="btn btn--primary btn--sm"
+          disabled={disabled}
+          onClick={applyDraft}
+        >
+          Apply
+        </button>
+      </div>
+      {error && (
+        <p className="time-filter__error" role="alert">
+          {error}
+        </p>
+      )}
+      <p className="time-filter__hint">
+        Active range: {formatRangeLabel(range)}
+        {compact ? " (narrows table only)" : ""}
+      </p>
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/RecentActivity.tsx
+++ b/web/metrics-dashboard/components/RecentActivity.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { formatDateTime, formatLatencyMs } from "@/lib/format";
+import type { MetricsSessionRow } from "@/lib/types";
+
+type Props = {
+  sessions: MetricsSessionRow[];
+  loading?: boolean;
+  onInspect?: (sessionId: string) => void;
+  inspectLoadingId?: string | null;
+  showTechnicalActions?: boolean;
+};
+
+function statusLabel(status: MetricsSessionRow["status"]): string {
+  if (status === "ok") return "Succeeded";
+  if (status === "error") return "Failed";
+  return "No data";
+}
+
+export function RecentActivity({
+  sessions,
+  loading,
+  onInspect,
+  inspectLoadingId,
+  showTechnicalActions = false,
+}: Props) {
+  if (loading) {
+    return (
+      <section className="panel">
+        <h2 className="panel__title">Recent customer requests</h2>
+        <p className="panel__hint">Loading…</p>
+      </section>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <section className="panel">
+        <h2 className="panel__title">Recent customer requests</h2>
+        <p className="panel__hint">
+          When someone uses this agent, each conversation will appear here with whether
+          it worked and how long it took.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel" aria-labelledby="activity-heading">
+      <h2 id="activity-heading" className="panel__title">
+        Recent customer requests
+      </h2>
+      <p className="panel__hint">
+        The latest conversations in the last 24 hours — newest first.
+      </p>
+      <ul className="activity-list">
+        {sessions.slice(0, 10).map((row) => {
+          const isLoading = inspectLoadingId === row.session_id;
+          return (
+            <li key={row.session_id} className="activity-item" data-status={row.status}>
+              <div className="activity-item__main">
+                <p className="activity-item__when">{formatDateTime(row.start_time)}</p>
+                <p className="activity-item__preview">
+                  {row.preview ?? "Conversation with this agent"}
+                </p>
+              </div>
+              <aside className="activity-item__stats">
+                <span className={`badge badge--${row.status}`}>
+                  {statusLabel(row.status)}
+                </span>
+                <span className="activity-item__time">
+                  {formatLatencyMs(row.latency_ms_p50)}
+                </span>
+                {showTechnicalActions && onInspect && (
+                  <button
+                    type="button"
+                    className="btn btn--sm btn--ghost"
+                    disabled={row.num_traces <= 0 || isLoading}
+                    onClick={() => onInspect(row.session_id)}
+                  >
+                    {isLoading ? "Loading…" : "Engineering details"}
+                  </button>
+                )}
+              </aside>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/web/metrics-dashboard/components/RequestTracesWorkspace.tsx
+++ b/web/metrics-dashboard/components/RequestTracesWorkspace.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { TraceGraphPanel } from "@/components/TraceGraphPanel";
+import {
+  filterSessionRows,
+  type SessionStatusFilter,
+} from "@/lib/session-filters";
+import { formatDateTime, formatLatencyMs, formatShortId } from "@/lib/format";
+import { formatRangeLabel } from "@/lib/time-range";
+import type { MetricsSessionRow, TraceDetailResponse } from "@/lib/types";
+import type { MetricsTimeRange } from "@/lib/time-range";
+
+const PAGE_SIZE = 10;
+
+type Props = {
+  sessions: MetricsSessionRow[];
+  globalRange: MetricsTimeRange;
+  loading?: boolean;
+  selectedSessionId: string | null;
+  traceLoadingSessionId: string | null;
+  trace: TraceDetailResponse | null;
+  traceLoading: boolean;
+  traceError: string | null;
+  onSelectSession: (sessionId: string) => void;
+};
+
+function statusLabel(status: MetricsSessionRow["status"]): string {
+  if (status === "ok") return "Success";
+  if (status === "error") return "Failed";
+  return "No data";
+}
+
+export function RequestTracesWorkspace({
+  sessions,
+  globalRange,
+  loading,
+  selectedSessionId,
+  traceLoadingSessionId,
+  trace,
+  traceLoading,
+  traceError,
+  onSelectSession,
+}: Props) {
+  const [page, setPage] = useState(0);
+  const [fullscreen, setFullscreen] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<SessionStatusFilter>("all");
+
+  const filteredSessions = useMemo(
+    () => filterSessionRows(sessions, { status: statusFilter }),
+    [sessions, statusFilter],
+  );
+
+  const pageCount = Math.max(1, Math.ceil(filteredSessions.length / PAGE_SIZE));
+
+  useEffect(() => {
+    setPage(0);
+  }, [filteredSessions.length, statusFilter, globalRange.startMs, globalRange.endMs]);
+
+  useEffect(() => {
+    if (page > pageCount - 1) {
+      setPage(Math.max(0, pageCount - 1));
+    }
+  }, [page, pageCount]);
+
+  useEffect(() => {
+    if (!fullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [fullscreen]);
+
+  const pageSessions = useMemo(() => {
+    const start = page * PAGE_SIZE;
+    return filteredSessions.slice(start, start + PAGE_SIZE);
+  }, [page, filteredSessions]);
+
+  const canvasBlock = (
+    <TraceGraphPanel
+      trace={trace}
+      loading={traceLoading}
+      error={traceError}
+      sessionId={selectedSessionId}
+      fullscreen={fullscreen}
+      onToggleFullscreen={() => setFullscreen((v) => !v)}
+      compact
+    />
+  );
+
+  if (fullscreen) {
+    return (
+      <section className="panel trace-workspace trace-workspace--fullscreen-mode">
+        <div className="trace-workspace__fullscreen-shell">
+          {canvasBlock}
+          <button
+            type="button"
+            className="btn trace-workspace__close-fs"
+            onClick={() => setFullscreen(false)}
+          >
+            Close
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (loading && sessions.length === 0) {
+    return (
+      <section className="panel trace-workspace" aria-busy="true">
+        <h2 className="panel__title">Request traces</h2>
+        <p className="panel__hint">Loading requests…</p>
+      </section>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <section className="panel trace-workspace">
+        <h2 className="panel__title">Request traces</h2>
+        <p className="panel__hint">
+          No requests in the selected time range ({formatRangeLabel(globalRange)}).
+          Widen the range above or send traffic to this agent.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel trace-workspace" aria-labelledby="traces-heading">
+      <header className="trace-workspace__header">
+        <div>
+          <h2 id="traces-heading" className="panel__title">
+            Request traces
+          </h2>
+          <p className="panel__hint">
+            {filteredSessions.length} of {sessions.length} in{" "}
+            {formatRangeLabel(globalRange)}
+            {filteredSessions.length > 0
+              ? ` · page ${page + 1} of ${pageCount}`
+              : ""}
+          </p>
+        </div>
+      </header>
+
+      <div className="trace-workspace__split">
+        <div className="trace-workspace__list">
+          <div className="trace-workspace__toolbar" role="toolbar" aria-label="Filter requests">
+            <div className="trace-filter-chips" role="group" aria-label="Status">
+              {(
+                [
+                  ["all", "All"],
+                  ["ok", "Success"],
+                  ["error", "Failed"],
+                ] as const
+              ).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={`trace-filter-chip${statusFilter === value ? " trace-filter-chip--active" : ""}`}
+                  aria-pressed={statusFilter === value}
+                  disabled={loading}
+                  onClick={() => setStatusFilter(value)}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <p className="trace-workspace__toolbar-hint">
+              Time range uses the filter above the chart. Click a row to view its path →
+            </p>
+          </div>
+
+          {filteredSessions.length === 0 ? (
+            <p className="panel__hint trace-workspace__empty">
+              No {statusFilter === "all" ? "" : statusFilter === "ok" ? "successful " : "failed "}
+              requests in this range.
+            </p>
+          ) : (
+            <>
+              <div className="trace-workspace__table-scroll">
+                <table className="data-table data-table--requests">
+                  <thead>
+                    <tr>
+                      <th scope="col">Time</th>
+                      <th scope="col">Preview</th>
+                      <th scope="col">Latency</th>
+                      <th scope="col">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pageSessions.map((row) => {
+                      const isSelected = selectedSessionId === row.session_id;
+                      const isRowLoading = traceLoadingSessionId === row.session_id;
+                      const clickable = row.num_traces > 0;
+                      return (
+                        <tr
+                          key={row.session_id}
+                          data-selected={isSelected || undefined}
+                          data-status={row.status}
+                          className={
+                            clickable ? "data-table__row--clickable" : "data-table__row--muted"
+                          }
+                          onClick={() => {
+                            if (clickable) onSelectSession(row.session_id);
+                          }}
+                        >
+                          <td>
+                            <time dateTime={row.start_time ?? undefined}>
+                              {formatDateTime(row.start_time)}
+                            </time>
+                            <span className="table-subtle" title={row.session_id}>
+                              {" "}
+                              · {formatShortId(row.session_id)}
+                            </span>
+                          </td>
+                          <td className="data-table__preview" title={row.preview ?? undefined}>
+                            {row.preview ?? "Conversation with this agent"}
+                          </td>
+                          <td>{formatLatencyMs(row.latency_ms_p50)}</td>
+                          <td>
+                            <span className={`badge badge--${row.status}`}>
+                              {isRowLoading ? "Loading…" : statusLabel(row.status)}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="pagination" role="navigation" aria-label="Request pages">
+                <button
+                  type="button"
+                  className="btn btn--sm"
+                  disabled={page <= 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                >
+                  Previous
+                </button>
+                <span className="pagination__label">
+                  {page * PAGE_SIZE + 1}–
+                  {Math.min((page + 1) * PAGE_SIZE, filteredSessions.length)} of{" "}
+                  {filteredSessions.length}
+                </span>
+                <button
+                  type="button"
+                  className="btn btn--sm"
+                  disabled={page >= pageCount - 1}
+                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                >
+                  Next
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="trace-workspace__canvas">{canvasBlock}</div>
+      </div>
+    </section>
+  );
+}

--- a/web/metrics-dashboard/components/SessionsTable.tsx
+++ b/web/metrics-dashboard/components/SessionsTable.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { formatDateTime, formatLatencyMs, formatShortId } from "@/lib/format";
+import type { MetricsSessionRow } from "@/lib/types";
+
+type Props = {
+  sessions: MetricsSessionRow[];
+  loading?: boolean;
+  selectedSessionId: string | null;
+  traceLoadingSessionId: string | null;
+  onViewTrace: (sessionId: string) => void;
+};
+
+export function SessionsTable({
+  sessions,
+  loading,
+  selectedSessionId,
+  traceLoadingSessionId,
+  onViewTrace,
+}: Props) {
+  if (loading) {
+    return (
+      <section className="panel" aria-busy="true">
+        <h2 className="panel__title">Recent sessions</h2>
+        <p className="panel__hint">Loading sessions…</p>
+      </section>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <section className="panel">
+        <h2 className="panel__title">Recent sessions</h2>
+        <p className="panel__hint">
+          No Phoenix sessions in the last 24 hours. Chat with the agent to create traces.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel" aria-labelledby="sessions-heading">
+      <h2 id="sessions-heading" className="panel__title">
+        Recent sessions
+      </h2>
+      <p className="panel__hint">
+        Select a session to load its request trace as a span graph below.
+      </p>
+      <div className="table-wrap">
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Session</th>
+              <th scope="col">Traces</th>
+              <th scope="col">Latency</th>
+              <th scope="col">Status</th>
+              <th scope="col">
+                <span className="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.slice(0, 20).map((row) => {
+              const isSelected = selectedSessionId === row.session_id;
+              const isLoading = traceLoadingSessionId === row.session_id;
+              return (
+                <tr
+                  key={row.session_id}
+                  data-selected={isSelected || undefined}
+                  data-status={row.status}
+                >
+                  <td>{formatDateTime(row.start_time)}</td>
+                  <td>
+                    <code title={row.session_id}>{formatShortId(row.session_id)}</code>
+                  </td>
+                  <td>{row.num_traces}</td>
+                  <td>{formatLatencyMs(row.latency_ms_p50)}</td>
+                  <td>
+                    <span className={`badge badge--${row.status}`}>{row.status}</span>
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      className="btn btn--sm"
+                      disabled={row.num_traces <= 0 || isLoading}
+                      onClick={() => onViewTrace(row.session_id)}
+                      aria-pressed={isSelected}
+                    >
+                      {isLoading ? "Loading…" : "View trace"}
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/web/metrics-dashboard/components/TraceGraphPanel.tsx
+++ b/web/metrics-dashboard/components/TraceGraphPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Background,
+  Controls,
+  ReactFlow,
+  type Edge,
+  type Node,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { formatLatencyMs } from "@/lib/format";
+import type { TraceDetailResponse } from "@/lib/types";
+import { workflowNodeTypes } from "@/components/workflow/WorkflowNodes";
+
+type Props = {
+  trace: TraceDetailResponse | null;
+  loading?: boolean;
+  error?: string | null;
+  sessionId?: string | null;
+  fullscreen?: boolean;
+  onToggleFullscreen?: () => void;
+  compact?: boolean;
+};
+
+export function TraceGraphPanel({
+  trace,
+  loading,
+  error,
+  sessionId,
+  fullscreen = false,
+  onToggleFullscreen,
+  compact = false,
+}: Props) {
+  const nodes: Node[] = useMemo(() => {
+    if (!trace) return [];
+    return trace.nodes.map((n) => ({
+      id: n.id,
+      position: n.position,
+      data: n.data,
+      type: "workflow",
+    }));
+  }, [trace]);
+
+  const edges: Edge[] = useMemo(() => {
+    if (!trace) return [];
+    return trace.edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      type: "smoothstep",
+      animated: true,
+      style: { stroke: "var(--border-strong, #64748b)", strokeWidth: 2 },
+    }));
+  }, [trace]);
+
+  const canvasClass = [
+    "trace-canvas",
+    compact ? "trace-canvas--compact" : "",
+    fullscreen ? "trace-canvas--fullscreen" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const header = (
+    <div className="trace-canvas__header">
+      <div>
+        <h3 className="trace-canvas__title">Request path</h3>
+        {trace && (
+          <p className="trace-canvas__meta">
+            {trace.nodes.length} step{trace.nodes.length === 1 ? "" : "s"}
+            {trace.latency_ms != null
+              ? ` · ${formatLatencyMs(trace.latency_ms)} total`
+              : ""}
+            {trace.truncated ? " · trace has more detail in Phoenix" : ""}
+          </p>
+        )}
+      </div>
+      {onToggleFullscreen && (
+        <button
+          type="button"
+          className="btn btn--sm"
+          onClick={onToggleFullscreen}
+          aria-pressed={fullscreen}
+        >
+          {fullscreen ? "Exit fullscreen" : "Fullscreen"}
+        </button>
+      )}
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className={canvasClass} aria-busy="true">
+        {header}
+        <p className="panel__hint">Loading workflow…</p>
+        <div className="trace-graph trace-graph--empty" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={canvasClass}>
+        {header}
+        <p className="panel__hint panel__hint--error" role="alert">
+          {error}
+        </p>
+      </div>
+    );
+  }
+
+  if (!trace || nodes.length === 0) {
+    return (
+      <div className={canvasClass}>
+        {header}
+        <p className="panel__hint">
+          {sessionId
+            ? "No workflow steps for this request."
+            : "Select a request from the table to see its path."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={canvasClass} aria-label="Request workflow diagram">
+      {header}
+      <p className="trace-canvas__legend">
+        <span className="trace-legend trace-legend--ok">Success</span>
+        <span className="trace-legend trace-legend--error">Failed</span>
+      </p>
+      <div className="trace-graph">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={workflowNodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.35 }}
+          minZoom={0.15}
+          maxZoom={1.25}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          panOnScroll
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background gap={20} color="var(--border)" />
+          <Controls showInteractive={false} position="bottom-right" />
+        </ReactFlow>
+      </div>
+    </div>
+  );
+}

--- a/web/metrics-dashboard/components/TrafficChart.tsx
+++ b/web/metrics-dashboard/components/TrafficChart.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  type TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { formatHourLabel, formatLatencyMs } from "@/lib/format";
+import type { MetricsHourlyPoint } from "@/lib/types";
+
+type Props = {
+  series: MetricsHourlyPoint[];
+  loading?: boolean;
+  noData?: boolean;
+};
+
+type BarRow = {
+  label: string;
+  ts: string;
+  success: number;
+  error: number;
+  latency_ms: number | null;
+};
+
+function formatBucketRange(iso: string): string {
+  const start = new Date(iso);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  const startLabel = start.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const endLabel = end.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${startLabel} – ${endLabel}`;
+}
+
+function TrafficTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+  const row = payload[0].payload as BarRow;
+  const total = row.success + row.error;
+  const hasLatency = row.latency_ms != null && Number.isFinite(row.latency_ms);
+  return (
+    <div className="chart-tooltip" role="tooltip">
+      <p className="chart-tooltip__time">{formatBucketRange(row.ts)}</p>
+      <dl className="chart-tooltip__rows">
+        <div>
+          <dt>Total requests</dt>
+          <dd>{total.toLocaleString()}</dd>
+        </div>
+        <div>
+          <dt>
+            <span className="legend-swatch legend-swatch--success" aria-hidden />
+            Successful
+          </dt>
+          <dd>{row.success.toLocaleString()}</dd>
+        </div>
+        <div>
+          <dt>
+            <span className="legend-swatch legend-swatch--error" aria-hidden />
+            Failed
+          </dt>
+          <dd className={row.error > 0 ? "chart-tooltip__err" : ""}>
+            {row.error.toLocaleString()}
+          </dd>
+        </div>
+        <div>
+          <dt>Typical response</dt>
+          <dd>{hasLatency ? formatLatencyMs(row.latency_ms) : "—"}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export function TrafficChart({ series, loading, noData }: Props) {
+  const data: BarRow[] = series.map((point) => ({
+    label: formatHourLabel(point.ts),
+    ts: point.ts,
+    success: Math.max(0, point.success ?? 0),
+    error: Math.max(0, point.error ?? 0),
+    latency_ms: point.latency_ms,
+  }));
+
+  const totalRequests = data.reduce((sum, d) => sum + d.success + d.error, 0);
+  const totalErrors = data.reduce((sum, d) => sum + d.error, 0);
+  const hasTraffic = totalRequests > 0;
+
+  if (loading) {
+    return (
+      <section className="panel" aria-busy="true">
+        <h2 className="panel__title">How busy is your agent?</h2>
+        <p className="panel__hint">Loading traffic chart…</p>
+        <div className="chart-skeleton" aria-hidden="true" />
+      </section>
+    );
+  }
+
+  if (noData || !hasTraffic) {
+    return (
+      <section className="panel">
+        <h2 className="panel__title">How busy is your agent?</h2>
+        <p className="panel__hint">
+          After customers start using this agent, you will see how many requests
+          arrived each hour — and which of them succeeded or failed.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel" aria-label="Hourly traffic for the last 24 hours">
+      <header className="panel__header">
+        <div>
+          <h2 className="panel__title">How busy is your agent?</h2>
+          <p className="panel__hint">
+            Requests per hour over the last 24h. Green is successful, red is failed.
+          </p>
+        </div>
+        <ul className="chart-legend chart-legend--inline" aria-label="Chart legend">
+          <li>
+            <span className="legend-swatch legend-swatch--success" aria-hidden /> Successful
+          </li>
+          <li>
+            <span className="legend-swatch legend-swatch--error" aria-hidden /> Failed
+          </li>
+        </ul>
+      </header>
+
+      <div className="chart-wrap">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={data}
+            margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
+            barCategoryGap={2}
+          >
+            <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: "var(--muted)", fontSize: 11 }}
+              tickLine={false}
+              axisLine={{ stroke: "var(--border)" }}
+              interval="preserveStartEnd"
+              minTickGap={28}
+            />
+            <YAxis
+              tick={{ fill: "var(--muted)", fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              width={36}
+              allowDecimals={false}
+              label={{
+                value: "Requests",
+                angle: -90,
+                position: "insideLeft",
+                offset: 12,
+                style: { fill: "var(--muted)", fontSize: 11 },
+              }}
+            />
+            <Tooltip
+              cursor={{ fill: "var(--border)", opacity: 0.25 }}
+              content={<TrafficTooltip />}
+            />
+            <Bar
+              dataKey="success"
+              stackId="traffic"
+              fill="var(--ok)"
+              radius={[0, 0, 0, 0]}
+              isAnimationActive={false}
+            />
+            <Bar
+              dataKey="error"
+              stackId="traffic"
+              fill="var(--bad)"
+              radius={[4, 4, 0, 0]}
+              isAnimationActive={false}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      <p className="chart-summary" aria-live="polite">
+        {totalRequests.toLocaleString()} total requests · {totalErrors.toLocaleString()} failed
+        {totalRequests > 0 && (
+          <>
+            {" "}
+            ({((totalErrors / totalRequests) * 100).toFixed(1)}% error rate)
+          </>
+        )}
+      </p>
+    </section>
+  );
+}

--- a/web/metrics-dashboard/components/metrics-dashboard.css
+++ b/web/metrics-dashboard/components/metrics-dashboard.css
@@ -1,0 +1,1592 @@
+.dashboard {
+  min-height: 100vh;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.dashboard__header {
+  margin-bottom: 1.75rem;
+}
+
+.dashboard__eyebrow {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  margin-bottom: 0.35rem;
+}
+
+.dashboard__title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.dashboard__subtitle {
+  color: var(--muted);
+  margin-top: 0.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.dashboard-sections {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.dashboard-nav {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.dashboard-nav__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.dashboard-nav__link:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.dashboard-nav__btn {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.45rem 0.85rem;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.dashboard-nav__btn:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--border) 40%, transparent);
+}
+
+.dashboard-nav__btn--active {
+  color: var(--text);
+  background: var(--bg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.time-filter {
+  margin-bottom: 1.25rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+}
+
+.time-filter--compact {
+  margin-bottom: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  flex: 1;
+  min-width: 280px;
+}
+
+.time-filter__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.time-filter__row {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr auto;
+  gap: 0.65rem;
+  align-items: end;
+}
+
+@media (max-width: 720px) {
+  .time-filter__row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .time-filter__row .field--inline:first-child {
+    grid-column: 1 / -1;
+  }
+
+  .time-filter__row .btn {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+}
+
+.time-filter__hint {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  margin-top: 0.5rem;
+}
+
+.time-filter__error {
+  font-size: 0.8125rem;
+  color: #f87171;
+  margin-top: 0.35rem;
+}
+
+.time-filter--compact .time-filter__hint {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+}
+
+.field--inline {
+  min-width: auto;
+}
+
+.field--inline label {
+  font-size: 0.7rem;
+}
+
+.field--inline input,
+.field--inline select {
+  appearance: none;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.8125rem;
+}
+
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  margin-bottom: 1.5rem;
+}
+
+.toolbar__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 220px;
+}
+
+.field label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.field select {
+  appearance: none;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.55rem 2rem 0.55rem 0.75rem;
+  font-size: 0.9375rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%238b9cb3'%3E%3Cpath d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.65rem center;
+}
+
+.field select:disabled {
+  opacity: 0.6;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* D3 — visible focus outline for every interactive element */
+.btn:focus-visible,
+.field select:focus-visible,
+.auth-panel input:focus-visible,
+.toggle input:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+/* D1 — auto-refresh toggle */
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  font-size: 0.8125rem;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle input {
+  accent-color: var(--accent);
+  margin: 0;
+}
+
+.toggle:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+/* D1 — status pill with relative timestamp */
+.status-pill {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
+.status-pill__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+  flex-shrink: 0;
+}
+
+.status-pill__dot--ready {
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
+}
+
+.status-pill__dot--loading {
+  background: var(--accent);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.status-pill__dot--error {
+  background: #ef4444;
+}
+
+.status-pill__dot--auth,
+.status-pill__dot--idle {
+  background: var(--muted);
+}
+
+.status-pill__text {
+  color: var(--text);
+}
+
+.status-pill__abs {
+  color: var(--muted);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-pill__dot--loading {
+    animation: none;
+  }
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 1100px) {
+  .kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.kpi-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+}
+
+.kpi-card[data-tone="bad"] {
+  border-color: #7f1d1d;
+}
+
+.kpi-card[data-tone="bad"] .kpi-card__value {
+  color: #f87171;
+}
+
+.kpi-card[data-tone="good"] .kpi-card__value {
+  color: #4ade80;
+}
+
+.kpi-card[aria-busy="true"] {
+  opacity: 0.8;
+}
+
+.kpi-card__label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.35rem;
+}
+
+.kpi-card__value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.kpi-card__hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+/* Latency sparkline inside the "Typical response time" KPI card */
+.sparkline {
+  width: 100%;
+  height: 36px;
+  margin-top: 0.4rem;
+}
+
+.sparkline--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.875rem;
+  border-top: 1px dashed var(--border);
+  padding-top: 0.4rem;
+  margin-top: 0.4rem;
+  height: auto;
+}
+
+/* Tier B — User feedback distribution bar inside KPI card */
+.feedback-bar {
+  margin-top: 0.5rem;
+}
+
+.feedback-bar__track {
+  display: flex;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+}
+
+.feedback-bar__seg {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+}
+
+.feedback-bar__seg--good {
+  background: var(--ok);
+}
+
+.feedback-bar__seg--bad {
+  background: var(--bad);
+}
+
+.feedback-bar__seg--neutral {
+  background: var(--accent);
+  opacity: 0.7;
+}
+
+.feedback-bar__seg--muted {
+  background: var(--muted);
+  opacity: 0.55;
+}
+
+.feedback-bar__legend {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.85rem;
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.feedback-bar__legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.feedback-bar__label {
+  color: var(--text);
+}
+
+.feedback-bar__pct {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.feedback-bar__swatch--good {
+  background: var(--ok);
+}
+.feedback-bar__swatch--bad {
+  background: var(--bad);
+}
+.feedback-bar__swatch--neutral {
+  background: var(--accent);
+  opacity: 0.7;
+}
+.feedback-bar__swatch--muted {
+  background: var(--muted);
+  opacity: 0.55;
+}
+
+/* Tier B — Prompt vs Completion cost split */
+.cost-split {
+  margin-top: 0.5rem;
+}
+
+.cost-split__track {
+  display: flex;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+}
+
+.cost-split__seg {
+  display: block;
+  height: 100%;
+}
+
+.cost-split__seg--prompt {
+  background: var(--accent);
+}
+
+.cost-split__seg--completion {
+  background: #8b5cf6;
+}
+
+.cost-split__legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.cost-split__legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.cost-split__swatch--prompt {
+  background: var(--accent);
+}
+
+.cost-split__swatch--completion {
+  background: #8b5cf6;
+}
+
+/* Challenge 1 — Logs page */
+.log-filter {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.log-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid transparent;
+  padding: 0.4rem 0.7rem;
+  border-radius: 7px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.log-chip:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.log-chip__count {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.log-chip--active {
+  background: var(--bg);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.log-chip--info.log-chip--active {
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+.log-chip--warn.log-chip--active {
+  border-color: rgba(250, 204, 21, 0.5);
+}
+
+.log-chip--error.log-chip--active {
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.logs-search {
+  appearance: none;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.9375rem;
+  width: 100%;
+}
+
+.logs-search:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.logs-panel {
+  padding: 0;
+  overflow: hidden;
+}
+
+.logs-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.logs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.logs-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.logs-table tbody td {
+  padding: 0.55rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.log-row__time {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  width: 1%;
+}
+
+.log-row__service {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  white-space: nowrap;
+  width: 1%;
+}
+
+.log-row__message {
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.log-row__meta {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  white-space: nowrap;
+  width: 1%;
+}
+
+.log-row--clickable {
+  cursor: pointer;
+}
+
+.log-row--clickable:hover td {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.log-row__detail td {
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0.85rem 0.75rem;
+}
+
+.log-row__detail pre {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.log-badge--info {
+  color: #93c5fd;
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.log-badge--warn {
+  color: #fde68a;
+  background: rgba(234, 179, 8, 0.12);
+  border-color: rgba(234, 179, 8, 0.4);
+}
+
+.log-badge--error {
+  color: #fca5a5;
+  background: rgba(239, 68, 68, 0.14);
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem;
+}
+
+.panel__title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.panel__hint {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.panel__header .panel__title,
+.panel__header .panel__hint {
+  margin: 0;
+}
+
+.panel__header .panel__hint {
+  font-size: 0.8125rem;
+  margin-top: 0.2rem;
+}
+
+.chart-wrap {
+  width: 100%;
+  height: 280px;
+}
+
+.chart-skeleton {
+  width: 100%;
+  height: 220px;
+  margin-top: 0.5rem;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.02) 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chart-skeleton {
+    animation: none;
+  }
+}
+
+.chart-legend {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.chart-legend--inline {
+  display: inline-flex;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  align-items: center;
+}
+
+.chart-legend--inline li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.legend-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  vertical-align: middle;
+  margin-right: 0.25rem;
+}
+
+.legend-swatch--success {
+  background: var(--ok);
+}
+
+.legend-swatch--error {
+  background: var(--bad);
+}
+
+.chart-summary {
+  margin-top: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* D2 — chart tooltip */
+.chart-tooltip {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+  color: var(--text);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  min-width: 14rem;
+}
+
+.chart-tooltip__time {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.chart-tooltip__rows {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+}
+
+.chart-tooltip__rows > div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8125rem;
+  gap: 1rem;
+}
+
+.chart-tooltip__rows dt {
+  color: var(--muted);
+}
+
+.chart-tooltip__rows dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.chart-tooltip__err {
+  color: #f87171;
+}
+
+.state-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.state-box--error {
+  border-color: #7f1d1d;
+  background: #1c1012;
+}
+
+.state-box h2 {
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.state-box p {
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 36rem;
+  margin: 0 auto 1rem;
+}
+
+.auth-panel {
+  margin-top: 1rem;
+  text-align: left;
+  max-width: 28rem;
+  margin-inline: auto;
+}
+
+.auth-panel input {
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.875rem;
+}
+
+.auth-panel small {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.auth-panel__actions {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.footer-meta {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+/* D3 — screen-reader-only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* D3 — skip link, visible only on focus */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 1rem;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5rem 0.85rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  text-decoration: none;
+  z-index: 10;
+}
+
+.skip-link:focus {
+  top: 1rem;
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.charts-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.exec-summary {
+  border-radius: 10px;
+  padding: 1.25rem 1.35rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid var(--border);
+}
+
+.exec-summary--good {
+  background: rgba(74, 222, 128, 0.08);
+  border-color: rgba(74, 222, 128, 0.35);
+}
+
+.exec-summary--warn {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.35);
+}
+
+.exec-summary--bad {
+  background: rgba(248, 113, 113, 0.08);
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.exec-summary--neutral {
+  background: var(--surface);
+}
+
+.exec-summary__headline {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.exec-summary__body {
+  color: var(--muted);
+  line-height: 1.55;
+  max-width: 42rem;
+}
+
+.activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.activity-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.activity-item__when {
+  font-size: 0.8125rem;
+  color: var(--muted);
+  margin-bottom: 0.25rem;
+}
+
+.activity-item__preview {
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+.activity-item__stats {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.activity-item__time {
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
+.technical-details {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem 1rem 1rem;
+  background: var(--surface);
+}
+
+.technical-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.technical-details__intro {
+  color: var(--muted);
+  font-size: 0.875rem;
+  margin: 0.75rem 0 1rem;
+  line-height: 1.5;
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--accent);
+  text-decoration: underline;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.chart-wrap--short,
+.chart-skeleton--short {
+  height: 220px;
+}
+
+
+.btn--sm {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8125rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  margin-top: 0.75rem;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.data-table th {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.data-table tr[data-selected] {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.badge--ok {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+
+.badge--error {
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+}
+
+.badge--unknown {
+  background: rgba(139, 156, 179, 0.15);
+  color: var(--muted);
+}
+
+.panel--trace {
+  margin-top: 1rem;
+}
+
+.panel__header-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__meta {
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
+.panel__hint--error {
+  color: #f87171;
+}
+
+.trace-graph {
+  width: 100%;
+  height: 420px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.trace-graph--empty {
+  min-height: 120px;
+}
+
+.span-node {
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  min-width: 140px;
+  font-size: 0.75rem;
+}
+
+.span-node--error {
+  border-color: #7f1d1d;
+}
+
+.span-node__name {
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
+.span-node__meta {
+  color: var(--muted);
+}
+
+/* —— Request traces split + n8n-style workflow nodes —— */
+
+.trace-workspace__header {
+  margin-bottom: 0.85rem;
+}
+
+.trace-workspace__split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 1rem;
+  align-items: stretch;
+  min-height: 420px;
+}
+
+@media (max-width: 960px) {
+  .trace-workspace__split {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+}
+
+.trace-workspace__list {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+.trace-workspace__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem 1rem;
+  margin-bottom: 0.65rem;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.trace-workspace__toolbar-hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0;
+  flex: 1 1 200px;
+}
+
+.trace-filter-chips {
+  display: inline-flex;
+  gap: 0.35rem;
+  padding: 0.2rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.trace-filter-chip {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.35rem 0.7rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.trace-filter-chip:hover {
+  color: var(--text);
+}
+
+.trace-filter-chip--active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.trace-filter-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.trace-workspace__table-scroll {
+  flex: 1;
+  min-height: 200px;
+  max-height: min(52vh, 520px);
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.trace-workspace__table-scroll .data-table {
+  margin: 0;
+}
+
+.trace-workspace__table-scroll thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--surface);
+}
+
+.trace-workspace__empty {
+  padding: 1.5rem 0;
+}
+
+.trace-workspace__canvas {
+  min-height: 420px;
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.data-table__row--muted {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.data-table__row--clickable {
+  cursor: pointer;
+}
+
+.data-table__row--clickable:hover {
+  background: rgba(99, 102, 241, 0.06);
+}
+
+.data-table__row--clickable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.data-table__preview {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.table-subtle {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pagination__label {
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
+.trace-canvas {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 340px;
+  padding: 0.75rem 0.85rem;
+}
+
+.trace-canvas--compact .trace-graph {
+  flex: 1;
+  min-height: 280px;
+  height: auto;
+}
+
+.trace-canvas__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.trace-canvas__title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.trace-canvas__meta {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 0.15rem;
+}
+
+.trace-canvas__legend {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.7rem;
+  margin-bottom: 0.5rem;
+}
+
+.trace-legend--ok::before,
+.trace-legend--error::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+}
+
+.trace-legend--ok::before {
+  background: #4ade80;
+}
+
+.trace-legend--error::before {
+  background: #f87171;
+}
+
+.trace-canvas--fullscreen {
+  min-height: calc(100vh - 2rem);
+}
+
+.trace-workspace--fullscreen-mode {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  margin: 0;
+  border-radius: 0;
+  max-width: none;
+  background: var(--bg);
+}
+
+.trace-workspace__fullscreen-shell {
+  position: relative;
+  height: 100vh;
+  padding: 1rem;
+}
+
+.trace-workspace__fullscreen-shell .trace-canvas {
+  min-height: calc(100vh - 4rem);
+}
+
+.trace-workspace__fullscreen-shell .trace-graph {
+  height: calc(100vh - 8rem);
+  min-height: 400px;
+}
+
+.trace-workspace__close-fs {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 2;
+}
+
+.wf-node {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  min-width: 150px;
+  max-width: 188px;
+  padding: 0.6rem 0.7rem;
+  border-radius: 10px;
+  border: 2px solid var(--border);
+  background: var(--surface);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  font-size: 0.75rem;
+}
+
+.wf-node--ok {
+  border-color: #22c55e;
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.25);
+}
+
+.wf-node--error {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.3);
+}
+
+.wf-node--neutral {
+  border-color: var(--border);
+}
+
+.wf-node--llm.wf-node--ok {
+  background: linear-gradient(145deg, rgba(16, 163, 127, 0.12), var(--surface));
+}
+
+.wf-node--user .wf-node__icon {
+  color: #93c5fd;
+}
+
+.wf-node--llm .wf-node__icon {
+  color: #10a37f;
+}
+
+.wf-node__icon {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wf-node__icon-svg {
+  width: 22px;
+  height: 22px;
+}
+
+.wf-node__title {
+  font-weight: 600;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.wf-node__subtitle {
+  color: var(--muted);
+  font-size: 0.65rem;
+  margin-top: 0.15rem;
+  line-height: 1.25;
+}
+
+.wf-node__meta {
+  color: var(--muted);
+  font-size: 0.65rem;
+  margin-top: 0.2rem;
+}
+
+.wf-node__handle {
+  width: 6px;
+  height: 6px;
+  background: var(--muted);
+  border: none;
+}

--- a/web/metrics-dashboard/components/workflow/WorkflowNodes.tsx
+++ b/web/metrics-dashboard/components/workflow/WorkflowNodes.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { formatLatencyMs } from "@/lib/format";
+import type { TraceGraphNode } from "@/lib/types";
+
+type WorkflowNodeData = TraceGraphNode["data"];
+
+function OpenAiIcon() {
+  return (
+    <svg
+      className="wf-node__icon-svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="currentColor"
+    >
+      <path d="M11.32 2.576a4.48 4.48 0 0 1 2.304.616 4.496 4.496 0 0 1 1.632 1.68l.048.096a4.48 4.48 0 0 1 .616 2.304 4.48 4.48 0 0 1-.616 2.304l-.048.096a4.496 4.496 0 0 1-1.68 1.632 4.48 4.48 0 0 1-2.304.616 4.48 4.48 0 0 1-2.304-.616 4.496 4.496 0 0 1-1.632-1.68l-.048-.096a4.48 4.48 0 0 1-.616-2.304 4.48 4.48 0 0 1 .616-2.304l.048-.096a4.496 4.496 0 0 1 1.68-1.632 4.48 4.48 0 0 1 2.304-.616zm.68 3.2a3.28 3.28 0 1 0 0 6.56 3.28 3.28 0 0 0 0-6.56zM6.4 11.52a3.28 3.28 0 1 0 0 6.56 3.28 3.28 0 0 0 0-6.56zm11.2 0a3.28 3.28 0 1 0 0 6.56 3.28 3.28 0 0 0 0-6.56zM12 17.6a3.28 3.28 0 1 0 0 6.56 3.28 3.28 0 0 0 0-6.56z" />
+    </svg>
+  );
+}
+
+function UserIcon() {
+  return (
+    <svg
+      className="wf-node__icon-svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M20 21a8 8 0 0 0-16 0" />
+      <circle cx="12" cy="8" r="4" />
+    </svg>
+  );
+}
+
+function AgentIcon() {
+  return (
+    <svg
+      className="wf-node__icon-svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <rect x="4" y="4" width="16" height="16" rx="3" />
+      <path d="M9 10h.01M15 10h.01M9.5 15a3 3 0 0 0 5 0" />
+    </svg>
+  );
+}
+
+function ToolIcon() {
+  return (
+    <svg
+      className="wf-node__icon-svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L4 17l3 3 5.3-5.3a4 4 0 0 0 5.4-5.4l-2.6-2.6z" />
+    </svg>
+  );
+}
+
+function StepIcon() {
+  return (
+    <svg
+      className="wf-node__icon-svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v4l3 2" />
+    </svg>
+  );
+}
+
+function NodeIcon({ kind }: { kind: WorkflowNodeData["node_kind"] }) {
+  switch (kind) {
+    case "user":
+      return <UserIcon />;
+    case "llm":
+      return <OpenAiIcon />;
+    case "agent":
+      return <AgentIcon />;
+    case "tool":
+      return <ToolIcon />;
+    default:
+      return <StepIcon />;
+  }
+}
+
+export function WorkflowNodeCard({ data }: NodeProps) {
+  const nodeData = data as WorkflowNodeData;
+  const kind = nodeData.node_kind ?? "step";
+  const tone = nodeData.tone ?? "neutral";
+
+  return (
+    <div className={`wf-node wf-node--${kind} wf-node--${tone}`}>
+      <Handle type="target" position={Position.Left} className="wf-node__handle" />
+      <Handle type="source" position={Position.Right} className="wf-node__handle" />
+      <div className="wf-node__icon" aria-hidden="true">
+        <NodeIcon kind={kind} />
+      </div>
+      <div className="wf-node__body">
+        <p className="wf-node__title" title={nodeData.label}>
+          {nodeData.label}
+        </p>
+        {nodeData.subtitle && (
+          <p className="wf-node__subtitle">{nodeData.subtitle}</p>
+        )}
+        {nodeData.latency_ms != null && (
+          <p className="wf-node__meta">{formatLatencyMs(nodeData.latency_ms)}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const workflowNodeTypes = { workflow: WorkflowNodeCard };

--- a/web/metrics-dashboard/eslint.config.mjs
+++ b/web/metrics-dashboard/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals", "next/typescript")];
+
+export default eslintConfig;

--- a/web/metrics-dashboard/lib/api-client.ts
+++ b/web/metrics-dashboard/lib/api-client.ts
@@ -1,0 +1,155 @@
+import { authHeaders } from "@/lib/auth-client";
+import { timeRangeQueryString, type MetricsTimeRange } from "@/lib/time-range";
+import type {
+  AgentMetricsResponse,
+  LogsResponse,
+  MetricsAgentOption,
+  SessionDetailResponse,
+  SessionsListResponse,
+  TraceDetailResponse,
+} from "@/lib/types";
+
+export class MetricsApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "MetricsApiError";
+  }
+}
+
+async function parseJson<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  if (!text) {
+    return {} as T;
+  }
+  return JSON.parse(text) as T;
+}
+
+export async function fetchAgents(
+  token: string,
+): Promise<MetricsAgentOption[]> {
+  const response = await fetch("/api/agents", {
+    headers: authHeaders(token),
+    cache: "no-store",
+  });
+  const body = await parseJson<{
+    agents?: MetricsAgentOption[];
+    error?: string;
+  }>(response);
+
+  if (!response.ok) {
+    throw new MetricsApiError(body.error ?? "Failed to load agents", response.status);
+  }
+  return body.agents ?? [];
+}
+
+export async function fetchAgentMetrics(
+  token: string,
+  agentId: string,
+  timeRange?: MetricsTimeRange,
+): Promise<AgentMetricsResponse> {
+  const qs = timeRange
+    ? timeRangeQueryString(timeRange)
+    : "window=24h";
+  const url = `/api/metrics?agent=${encodeURIComponent(agentId)}&${qs}`;
+  const response = await fetch(url, {
+    headers: authHeaders(token),
+    cache: "no-store",
+  });
+  const body = await parseJson<AgentMetricsResponse & { error?: string }>(response);
+
+  if (!response.ok) {
+    throw new MetricsApiError(body.error ?? "Failed to load metrics", response.status);
+  }
+  return body;
+}
+
+export async function fetchAgentSessions(
+  token: string,
+  agentId: string,
+  timeRange?: MetricsTimeRange,
+): Promise<SessionsListResponse> {
+  const qs = timeRange
+    ? timeRangeQueryString(timeRange)
+    : "window=24h";
+  const url = `/api/sessions?agent=${encodeURIComponent(agentId)}&${qs}`;
+  const response = await fetch(url, {
+    headers: authHeaders(token),
+    cache: "no-store",
+  });
+  const body = await parseJson<SessionsListResponse & { error?: string }>(response);
+  if (!response.ok) {
+    throw new MetricsApiError(body.error ?? "Failed to load sessions", response.status);
+  }
+  return body;
+}
+
+export async function fetchSessionDetail(
+  token: string,
+  agentId: string,
+  sessionId: string,
+  window = "24h",
+): Promise<SessionDetailResponse> {
+  const url = `/api/sessions/${encodeURIComponent(sessionId)}?agent=${encodeURIComponent(agentId)}&window=${encodeURIComponent(window)}`;
+  const response = await fetch(url, {
+    headers: authHeaders(token),
+    cache: "no-store",
+  });
+  const body = await parseJson<SessionDetailResponse & { error?: string }>(response);
+  if (!response.ok) {
+    throw new MetricsApiError(body.error ?? "Failed to load session", response.status);
+  }
+  return body;
+}
+
+export async function fetchLogs(
+  token: string,
+  window = "24h",
+  signal?: AbortSignal,
+): Promise<LogsResponse> {
+  const response = await fetch(
+    `/api/logs?window=${encodeURIComponent(window)}`,
+    {
+      headers: authHeaders(token),
+      cache: "no-store",
+      signal,
+    },
+  );
+  const body = await parseJson<LogsResponse & { error?: string }>(response);
+  if (!response.ok) {
+    throw new MetricsApiError(body.error ?? "Failed to load logs", response.status);
+  }
+  return body;
+}
+
+export async function fetchTraceGraph(
+  token: string,
+  agentId: string,
+  traceId: string,
+  projectId?: string | null,
+  window = "24h",
+  userPreview?: string | null,
+): Promise<TraceDetailResponse> {
+  const params = new URLSearchParams({
+    agent: agentId,
+    traceId,
+    window,
+  });
+  if (projectId) {
+    params.set("projectId", projectId);
+  }
+  if (userPreview?.trim()) {
+    params.set("userPreview", userPreview.trim());
+  }
+  const response = await fetch(`/api/traces?${params}`, {
+    headers: authHeaders(token),
+    cache: "no-store",
+  });
+  const body = await parseJson<TraceDetailResponse & { error?: string }>(response);
+  if (!response.ok) {
+    throw new MetricsApiError(body.error ?? "Failed to load trace", response.status);
+  }
+  return body;
+}

--- a/web/metrics-dashboard/lib/auth-client.ts
+++ b/web/metrics-dashboard/lib/auth-client.ts
@@ -1,0 +1,59 @@
+/** Browser-only: read Nasiko JWT for /api/* calls. */
+
+const DEV_TOKEN_KEY = "nasiko-metrics-dev-token";
+
+export function findNasikoCredentialsKey(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith("nasiko-credentials-")) {
+      return key;
+    }
+  }
+  return null;
+}
+
+export function getAccessTokenFromStorage(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const devToken = sessionStorage.getItem(DEV_TOKEN_KEY);
+  if (devToken?.trim()) {
+    return devToken.trim();
+  }
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key?.startsWith("nasiko-credentials-")) {
+      continue;
+    }
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) {
+        continue;
+      }
+      const parsed = JSON.parse(raw) as { access_token?: string };
+      if (parsed.access_token) {
+        return parsed.access_token;
+      }
+    } catch {
+      /* ignore malformed entries */
+    }
+  }
+  return null;
+}
+
+export function setDevAccessToken(token: string): void {
+  sessionStorage.setItem(DEV_TOKEN_KEY, token.trim());
+}
+
+export function clearDevAccessToken(): void {
+  sessionStorage.removeItem(DEV_TOKEN_KEY);
+}
+
+export function authHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}

--- a/web/metrics-dashboard/lib/auth.ts
+++ b/web/metrics-dashboard/lib/auth.ts
@@ -1,0 +1,34 @@
+/**
+ * Auth helpers for Route Handlers — forward Nasiko session JWT from the browser.
+ */
+
+export function getBearerFromAuthorizationHeader(
+  authorization: string | null,
+): string | null {
+  if (!authorization) {
+    return null;
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+  return match?.[1] ?? null;
+}
+
+export function getAuthorizationHeader(request: Request): string | null {
+  return request.headers.get("authorization");
+}
+
+/** Returns `Bearer <token>` for nasikoFetch, or null if missing/invalid. */
+export function getBearerAuthForNasiko(request: Request): string | null {
+  const header = getAuthorizationHeader(request);
+  if (!header?.startsWith("Bearer ")) {
+    return null;
+  }
+  const token = getBearerFromAuthorizationHeader(header);
+  if (!token) {
+    return null;
+  }
+  return `Bearer ${token}`;
+}
+
+export function unauthorizedResponse(message = "Unauthorized"): Response {
+  return Response.json({ error: message }, { status: 401 });
+}

--- a/web/metrics-dashboard/lib/fleet-rollup.ts
+++ b/web/metrics-dashboard/lib/fleet-rollup.ts
@@ -1,0 +1,96 @@
+import type { AgentMetricsResponse, MetricsAgentOption } from "@/lib/types";
+
+export type FleetAgentRow = {
+  agentId: string;
+  name: string;
+  metrics: AgentMetricsResponse;
+};
+
+export function aggregateFleetMetrics(
+  agents: MetricsAgentOption[],
+  perAgent: AgentMetricsResponse[],
+  window: string,
+): { aggregated: AgentMetricsResponse; rows: FleetAgentRow[] } {
+  const rows: FleetAgentRow[] = agents.map((agent, i) => ({
+    agentId: agent.agentId,
+    name: agent.name,
+    metrics: perAgent[i] ?? emptyRow(agent.agentId, window),
+  }));
+
+  let success = 0;
+  let error = 0;
+  let cost = 0;
+  let latencyWeighted = 0;
+  let latencyWeight = 0;
+  const uptimeValues: number[] = [];
+  let agentsWithData = 0;
+
+  for (const m of perAgent) {
+    if (!m.no_data) {
+      agentsWithData += 1;
+    }
+    success += m.success ?? 0;
+    error += m.error ?? 0;
+    const weight = (m.success ?? 0) + (m.error ?? 0);
+    if (m.avg_latency_ms != null && weight > 0) {
+      latencyWeighted += m.avg_latency_ms * weight;
+      latencyWeight += weight;
+    }
+    if (m.uptime_pct != null && Number.isFinite(m.uptime_pct)) {
+      uptimeValues.push(m.uptime_pct);
+    }
+    if (m.source?.cost_usd != null && Number.isFinite(m.source.cost_usd)) {
+      cost += m.source.cost_usd;
+    }
+  }
+
+  const avgLatencyMs =
+    latencyWeight > 0 ? Math.round(latencyWeighted / latencyWeight) : null;
+
+  const uptimePct =
+    uptimeValues.length > 0
+      ? Math.round(
+          (uptimeValues.reduce((a, b) => a + b, 0) / uptimeValues.length) * 10,
+        ) / 10
+      : null;
+
+  const aggregated: AgentMetricsResponse = {
+    agent: "__all__",
+    window,
+    avg_latency_ms: avgLatencyMs,
+    success,
+    error,
+    uptime_pct: uptimePct,
+    series_24h: [],
+    no_data: agentsWithData === 0,
+    message:
+      agentsWithData === 0
+        ? "No agent has traffic in the last 24 hours yet."
+        : undefined,
+    source: {
+      trace_count: perAgent.reduce((n, m) => n + (m.source?.trace_count ?? 0), 0),
+      latency_ms_p50: null,
+      latency_ms_p99: null,
+      cost_usd: cost > 0 ? cost : null,
+      session_count: perAgent.reduce(
+        (n, m) => n + (m.source?.session_count ?? 0),
+        0,
+      ),
+    },
+  };
+
+  return { aggregated, rows };
+}
+
+function emptyRow(agentId: string, window: string): AgentMetricsResponse {
+  return {
+    agent: agentId,
+    window,
+    avg_latency_ms: null,
+    success: 0,
+    error: 0,
+    uptime_pct: null,
+    series_24h: [],
+    no_data: true,
+  };
+}

--- a/web/metrics-dashboard/lib/format.ts
+++ b/web/metrics-dashboard/lib/format.ts
@@ -1,0 +1,96 @@
+export function formatLatencyMs(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms)) {
+    return "—";
+  }
+  if (ms < 1000) {
+    return `${Math.round(ms)} ms`;
+  }
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+export function formatPercent(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "—";
+  }
+  return `${value.toFixed(1)}%`;
+}
+
+export function formatCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "—";
+  }
+  return value.toLocaleString();
+}
+
+export function formatHourLabel(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+export function formatCostUsd(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "—";
+  }
+  if (value < 0.01) {
+    return `$${value.toFixed(4)}`;
+  }
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatShortId(id: string, head = 8, tail = 4): string {
+  if (id.length <= head + tail + 1) {
+    return id;
+  }
+  return `${id.slice(0, head)}…${id.slice(-tail)}`;
+}
+
+/**
+ * Tier B — Display a quality/satisfaction score. Scores live on whatever scale
+ * the underlying annotation uses (often 0–1, 0–5, or 0–100). We:
+ *   - if value is 0..1, show one decimal as %
+ *   - if value is 1..5, show "/5"
+ *   - if value is 5..100, show "/100"
+ *   - else, show the raw rounded number
+ */
+export function formatQualityScore(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "—";
+  }
+  if (value > 0 && value <= 1) {
+    return `${(value * 100).toFixed(0)}%`;
+  }
+  if (value <= 5) {
+    return `${value.toFixed(1)} / 5`;
+  }
+  if (value <= 100) {
+    return `${value.toFixed(0)} / 100`;
+  }
+  return value.toFixed(1);
+}
+
+/** Tier B — "3.4 steps" or "—" when no orchestration data. */
+export function formatSteps(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "—";
+  }
+  if (value >= 10) {
+    return `${Math.round(value)} steps`;
+  }
+  return `${value.toFixed(1)} steps`;
+}
+
+export function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) {
+    return "—";
+  }
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) {
+    return "—";
+  }
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/web/metrics-dashboard/lib/logs.test.ts
+++ b/web/metrics-dashboard/lib/logs.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  countByLevel,
+  filterLogs,
+  rowsFromRegistry,
+  rowsFromSession,
+  synthesizeLogs,
+  WARNING_LATENCY_MS,
+} from "@/lib/logs";
+import type {
+  NasikoObservabilitySession,
+  NasikoSimpleUserAgent,
+  SyntheticLogRow,
+} from "@/lib/types";
+
+describe("rowsFromSession", () => {
+  it("emits start + end rows for a normal session", () => {
+    const session: NasikoObservabilitySession = {
+      agent_id: "a2a-translator",
+      session_id: "sess-1",
+      start_time: "2026-05-17T10:00:00.000Z",
+      end_time: "2026-05-17T10:00:02.000Z",
+      num_traces: 1,
+      trace_latency_ms_p50: 1500,
+      last_output: { value: "Bonjour, comment allez-vous?" },
+    };
+    const rows = rowsFromSession(session);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].level).toBe("INFO");
+    expect(rows[0].message).toMatch(/Request received/);
+    expect(rows[1].level).toBe("INFO");
+    expect(rows[1].message).toMatch(/Completed/);
+    expect(rows[1].latency_ms).toBe(1500);
+  });
+
+  it("downgrades the end row to WARNING when p50 latency exceeds threshold", () => {
+    const session: NasikoObservabilitySession = {
+      agent_id: "a2a-translator",
+      session_id: "sess-slow",
+      start_time: "2026-05-17T10:00:00.000Z",
+      end_time: "2026-05-17T10:00:08.000Z",
+      num_traces: 1,
+      trace_latency_ms_p50: WARNING_LATENCY_MS + 1,
+      last_output: { value: "done" },
+    };
+    const rows = rowsFromSession(session);
+    const endRow = rows[1];
+    expect(endRow.level).toBe("WARNING");
+    expect(endRow.message).toMatch(/Slow response/);
+  });
+
+  it("emits an ERROR end row when the session looks errored", () => {
+    const session: NasikoObservabilitySession = {
+      agent_id: "a2a-translator",
+      session_id: "sess-err",
+      start_time: "2026-05-17T10:00:00.000Z",
+      end_time: "2026-05-17T10:00:01.000Z",
+      num_traces: 1,
+      trace_latency_ms_p50: 800,
+      last_output: { value: "Error code: 500 - service unavailable" },
+    };
+    const rows = rowsFromSession(session);
+    expect(rows[1].level).toBe("ERROR");
+  });
+});
+
+describe("rowsFromRegistry", () => {
+  it("emits one INFO row per agent at the snapshot time", () => {
+    const agents: NasikoSimpleUserAgent[] = [
+      { agent_id: "a2a-translator", name: "Translator Agent" },
+      { agent_id: "a2a-router", name: "Router Agent" },
+    ];
+    const rows = rowsFromRegistry(agents, "2026-05-17T12:00:00.000Z");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].level).toBe("INFO");
+    expect(rows[0].service).toBe("registry");
+    expect(rows[0].message).toMatch(/Translator Agent/);
+  });
+});
+
+describe("synthesizeLogs", () => {
+  it("sorts newest first and combines sources", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      {
+        agent_id: "a2a-translator",
+        session_id: "old",
+        start_time: "2026-05-17T08:00:00.000Z",
+        end_time: "2026-05-17T08:00:01.000Z",
+        last_output: { value: "ok" },
+      },
+      {
+        agent_id: "a2a-translator",
+        session_id: "new",
+        start_time: "2026-05-17T11:00:00.000Z",
+        end_time: "2026-05-17T11:00:01.000Z",
+        last_output: { value: "ok" },
+      },
+    ];
+    const agents: NasikoSimpleUserAgent[] = [
+      { agent_id: "a2a-translator", name: "Translator Agent" },
+    ];
+    const { logs, source_counts } = synthesizeLogs({
+      sessions,
+      agents,
+      generatedAt: new Date("2026-05-17T12:00:00.000Z"),
+    });
+
+    expect(source_counts.sessions).toBe(4);
+    expect(source_counts.registry).toBe(1);
+    expect(logs[0].ts >= logs[logs.length - 1].ts).toBe(true);
+    expect(logs[0].service).toBe("registry"); // snapshot at 12:00 is newest
+  });
+
+  it("respects maxRows cap", () => {
+    const sessions: NasikoObservabilitySession[] = Array.from({ length: 50 }, (_, i) => ({
+      agent_id: "a2a-translator",
+      session_id: `s-${i}`,
+      start_time: `2026-05-17T10:${String(i % 60).padStart(2, "0")}:00.000Z`,
+      last_output: { value: "ok" },
+    }));
+    const { logs } = synthesizeLogs({
+      sessions,
+      agents: [],
+      generatedAt: new Date("2026-05-17T12:00:00.000Z"),
+      maxRows: 10,
+    });
+    expect(logs).toHaveLength(10);
+  });
+});
+
+describe("filterLogs", () => {
+  const rows: SyntheticLogRow[] = [
+    {
+      id: "1",
+      ts: "2026-05-17T10:00:00.000Z",
+      level: "INFO",
+      service: "agent:a2a-translator",
+      message: "Request received by a2a-translator",
+    },
+    {
+      id: "2",
+      ts: "2026-05-17T10:00:01.000Z",
+      level: "ERROR",
+      service: "agent:a2a-translator",
+      message: "Request failed — timeout",
+    },
+    {
+      id: "3",
+      ts: "2026-05-17T10:00:02.000Z",
+      level: "WARNING",
+      service: "agent:a2a-router",
+      message: "Slow response (6s)",
+    },
+  ];
+
+  it("filters by level set", () => {
+    const out = filterLogs(rows, { levels: new Set(["ERROR"]) });
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("2");
+  });
+
+  it("filters by free-text search across message/service/agent", () => {
+    const out = filterLogs(rows, { search: "router" });
+    expect(out).toHaveLength(1);
+    expect(out[0].service).toBe("agent:a2a-router");
+  });
+
+  it("counts by level", () => {
+    expect(countByLevel(rows)).toEqual({ INFO: 1, WARNING: 1, ERROR: 1 });
+  });
+});

--- a/web/metrics-dashboard/lib/logs.ts
+++ b/web/metrics-dashboard/lib/logs.ts
@@ -1,0 +1,205 @@
+/**
+ * Challenge 1 — Synthesize a "platform activity log" from existing
+ * observability data (sessions) + registry snapshot. No Nasiko API changes.
+ *
+ * Each session contributes one or two log rows depending on whether it
+ * succeeded or errored. The registry contributes one INFO row per visible
+ * agent ("Agent online" at the time the snapshot was taken).
+ *
+ * Pure functions — no I/O — so this is easy to unit test.
+ */
+
+import type {
+  LogLevel,
+  NasikoObservabilitySession,
+  NasikoSimpleUserAgent,
+  SyntheticLogRow,
+} from "@/lib/types";
+import { isSessionError } from "@/lib/rollup";
+
+/** Slow request threshold: sessions with p50 latency above this become WARNING. */
+export const WARNING_LATENCY_MS = 5_000;
+
+function sessionPreview(session: NasikoObservabilitySession): string {
+  const raw = session.last_output;
+  const text = typeof raw === "string" ? raw : raw?.value;
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return "";
+  if (trimmed.length <= 140) return trimmed;
+  return `${trimmed.slice(0, 137)}…`;
+}
+
+function sessionService(session: NasikoObservabilitySession): string {
+  return session.agent_id ? `agent:${session.agent_id}` : "agent";
+}
+
+function endTs(session: NasikoObservabilitySession): string | null {
+  return (
+    session.end_time ?? session.start_time ?? null
+  );
+}
+
+function safeIso(ts: string | null | undefined): string | null {
+  if (!ts) return null;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
+/**
+ * Convert one session into 1–2 log rows:
+ *   - Always emit a "started" INFO row (timestamp = start_time).
+ *   - On completion, emit either INFO (success) or ERROR (failure).
+ *   - If success but p50 latency > WARNING_LATENCY_MS, downgrade to WARNING.
+ */
+export function rowsFromSession(
+  session: NasikoObservabilitySession,
+): SyntheticLogRow[] {
+  const rows: SyntheticLogRow[] = [];
+  const startIso = safeIso(session.start_time);
+  const endIso = safeIso(endTs(session));
+  const service = sessionService(session);
+  const preview = sessionPreview(session);
+  const errored = isSessionError(session);
+  const latency = session.trace_latency_ms_p50 ?? null;
+  const slow =
+    latency != null && Number.isFinite(latency) && latency > WARNING_LATENCY_MS;
+  const sessionId = session.session_id ?? null;
+
+  if (startIso) {
+    rows.push({
+      id: `sess:${sessionId ?? startIso}:start`,
+      ts: startIso,
+      level: "INFO",
+      service,
+      message: `Request received${session.agent_id ? ` by ${session.agent_id}` : ""}`,
+      agent_id: session.agent_id ?? null,
+      session_id: sessionId,
+      latency_ms: null,
+    });
+  }
+
+  if (endIso) {
+    let level: LogLevel = errored ? "ERROR" : slow ? "WARNING" : "INFO";
+    let message: string;
+    if (errored) {
+      message = preview
+        ? `Request failed — ${preview}`
+        : `Request failed`;
+    } else if (slow) {
+      message = `Slow response (${Math.round((latency as number) / 1000)}s)${
+        preview ? ` — ${preview}` : ""
+      }`;
+    } else if (preview) {
+      message = `Completed — ${preview}`;
+    } else {
+      message = `Completed`;
+    }
+    // Demote slow rows from ERROR only if errored was false (we already set level above)
+    if (errored && slow && latency != null) {
+      message = `${message} (${Math.round((latency as number) / 1000)}s)`;
+      level = "ERROR";
+    }
+    rows.push({
+      id: `sess:${sessionId ?? endIso}:end`,
+      ts: endIso,
+      level,
+      service,
+      message,
+      agent_id: session.agent_id ?? null,
+      session_id: sessionId,
+      latency_ms: latency,
+    });
+  }
+
+  return rows;
+}
+
+/** Registry snapshot: one INFO row per agent currently online. */
+export function rowsFromRegistry(
+  agents: NasikoSimpleUserAgent[],
+  snapshotAtIso: string,
+): SyntheticLogRow[] {
+  return agents.map((agent) => ({
+    id: `reg:${agent.agent_id}:${snapshotAtIso}`,
+    ts: snapshotAtIso,
+    level: "INFO" as const,
+    service: "registry",
+    message: `Agent online · ${agent.name ?? agent.agent_id}`,
+    agent_id: agent.agent_id,
+    detail: {
+      tags: agent.tags ?? [],
+      description: agent.description ?? null,
+    },
+  }));
+}
+
+/** Cap so we don't ship a 50k-row payload to the browser. */
+export const DEFAULT_MAX_LOGS = 500;
+
+export type SynthesizeInput = {
+  sessions: NasikoObservabilitySession[];
+  agents: NasikoSimpleUserAgent[];
+  generatedAt: Date;
+  maxRows?: number;
+};
+
+/**
+ * Top-level synthesizer. Combines all sources, sorts newest-first, and caps
+ * the result. Returns rows ready for `/api/logs` response.
+ */
+export function synthesizeLogs(input: SynthesizeInput): {
+  logs: SyntheticLogRow[];
+  source_counts: { sessions: number; registry: number };
+} {
+  const generatedAtIso = input.generatedAt.toISOString();
+  const sessionRows = input.sessions.flatMap(rowsFromSession);
+  const registryRows = rowsFromRegistry(input.agents, generatedAtIso);
+
+  const all = [...sessionRows, ...registryRows].sort((a, b) =>
+    b.ts.localeCompare(a.ts),
+  );
+
+  const max = input.maxRows ?? DEFAULT_MAX_LOGS;
+  return {
+    logs: all.slice(0, max),
+    source_counts: {
+      sessions: sessionRows.length,
+      registry: registryRows.length,
+    },
+  };
+}
+
+/** Client-side filter helpers (called from the LogsView). */
+export type LogsFilter = {
+  levels?: ReadonlySet<LogLevel>;
+  search?: string;
+};
+
+export function filterLogs(
+  rows: SyntheticLogRow[],
+  filter: LogsFilter,
+): SyntheticLogRow[] {
+  const needle = filter.search?.trim().toLowerCase() ?? "";
+  return rows.filter((row) => {
+    if (filter.levels && filter.levels.size > 0 && !filter.levels.has(row.level)) {
+      return false;
+    }
+    if (needle) {
+      const hay =
+        `${row.message} ${row.service} ${row.agent_id ?? ""} ${row.session_id ?? ""}`.toLowerCase();
+      if (!hay.includes(needle)) return false;
+    }
+    return true;
+  });
+}
+
+/** Compact level counts for the toolbar badges. */
+export function countByLevel(
+  rows: SyntheticLogRow[],
+): Record<LogLevel, number> {
+  const counts: Record<LogLevel, number> = { INFO: 0, WARNING: 0, ERROR: 0 };
+  for (const row of rows) {
+    counts[row.level] += 1;
+  }
+  return counts;
+}

--- a/web/metrics-dashboard/lib/metrics.ts
+++ b/web/metrics-dashboard/lib/metrics.ts
@@ -1,0 +1,56 @@
+/**
+ * Window helpers and empty-state metrics (rollup in `lib/rollup.ts`).
+ */
+
+import type { AgentMetricsResponse, MetricsHourlyPoint } from "@/lib/types";
+import { buildHourlyBuckets } from "@/lib/rollup";
+
+const SUPPORTED_WINDOWS = new Set(["1h", "24h", "7d"]);
+
+export function parseMetricsWindow(
+  raw: string | null,
+): { window: string; hours: number } | { error: string } {
+  const window = (raw ?? "24h").trim().toLowerCase();
+  if (!SUPPORTED_WINDOWS.has(window)) {
+    return {
+      error: `Unsupported window "${window}". Supported: ${[...SUPPORTED_WINDOWS].join(", ")}`,
+    };
+  }
+  const hours =
+    window === "1h" ? 1 : window === "7d" ? 24 * 7 : 24;
+  return { window, hours };
+}
+
+/** ISO-8601 UTC for Nasiko `start_time` query param. */
+export function computeStartTimeIso(hours: number, now = Date.now()): string {
+  return new Date(now - hours * 60 * 60 * 1000).toISOString();
+}
+
+function buildEmptySeries24h(now = Date.now()): MetricsHourlyPoint[] {
+  return buildHourlyBuckets(24, now).map((ts) => ({
+    ts,
+    latency_ms: null,
+    success: null,
+    error: null,
+  }));
+}
+
+/** Metrics when Phoenix has no project for this agent yet (no traces ingested). */
+export function emptyAgentMetrics(
+  agentId: string,
+  window: string,
+  message: string,
+): AgentMetricsResponse {
+  return {
+    agent: agentId,
+    window,
+    avg_latency_ms: null,
+    success: 0,
+    error: 0,
+    uptime_pct: null,
+    series_24h: buildEmptySeries24h(),
+    no_data: true,
+    message,
+  };
+}
+

--- a/web/metrics-dashboard/lib/nasiko.ts
+++ b/web/metrics-dashboard/lib/nasiko.ts
@@ -1,0 +1,159 @@
+/**
+ * Server-side Nasiko API client (Route Handlers only).
+ * Base URL is Kong in local dev; use http://nasiko-backend:8000 inside Docker compose.
+ */
+
+import type {
+  NasikoAgentStatsResponse,
+  NasikoObservabilitySessionsResponse,
+  NasikoSimpleUserAgentsResponse,
+} from "@/lib/types";
+
+const DEFAULT_NASIKO_API_URL = "http://localhost:9100";
+
+export function getNasikoApiUrl(): string {
+  const base = process.env.NASIKO_API_URL?.trim() || DEFAULT_NASIKO_API_URL;
+  return base.replace(/\/$/, "");
+}
+
+export class NasikoApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: string,
+  ) {
+    super(message);
+    this.name = "NasikoApiError";
+  }
+}
+
+export type NasikoFetchOptions = {
+  /** Full `Authorization` header value, e.g. `Bearer <token>`. */
+  authorization?: string;
+  /** Query params appended to the path. */
+  searchParams?: Record<string, string | undefined>;
+  cache?: RequestCache;
+};
+
+/**
+ * GET (or custom method) against Nasiko. Path must start with `/`, e.g. `/api/v1/healthcheck`.
+ */
+export async function nasikoFetch<T = unknown>(
+  path: string,
+  options: NasikoFetchOptions & { method?: "GET" } = {},
+): Promise<T> {
+  const method = options.method ?? "GET";
+  const base = getNasikoApiUrl();
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${base}${normalizedPath}`);
+
+  if (options.searchParams) {
+    for (const [key, value] of Object.entries(options.searchParams)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  const headers: HeadersInit = {
+    Accept: "application/json",
+  };
+  if (options.authorization) {
+    headers.Authorization = options.authorization;
+  }
+
+  const response = await fetch(url.toString(), {
+    method,
+    headers,
+    cache: options.cache ?? "no-store",
+  });
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new NasikoApiError(
+      `Nasiko ${method} ${normalizedPath} failed`,
+      response.status,
+      bodyText,
+    );
+  }
+
+  if (!bodyText) {
+    return undefined as T;
+  }
+
+  try {
+    return JSON.parse(bodyText) as T;
+  } catch {
+    return bodyText as T;
+  }
+}
+
+/** Kong gateway health (no auth). */
+export function fetchNasikoGatewayHealth(): Promise<unknown> {
+  return nasikoFetch("/health");
+}
+
+/** Backend health via Kong proxy. */
+export function fetchNasikoBackendHealthcheck(): Promise<unknown> {
+  return nasikoFetch("/api/v1/healthcheck");
+}
+
+/** Agents visible to the authenticated user. */
+export function fetchNasikoUserAgents(
+  authorization: string,
+): Promise<NasikoSimpleUserAgentsResponse> {
+  return nasikoFetch<NasikoSimpleUserAgentsResponse>(
+    "/api/v1/registry/user/agents",
+    { authorization },
+  );
+}
+
+/** Phoenix project stats for one agent over a time window. */
+export function fetchNasikoAgentStats(
+  authorization: string,
+  agentId: string,
+  startTimeIso: string,
+): Promise<NasikoAgentStatsResponse> {
+  return nasikoFetch<NasikoAgentStatsResponse>(
+    `/api/v1/observability/agent/${encodeURIComponent(agentId)}/stats`,
+    {
+      authorization,
+      searchParams: { start_time: startTimeIso },
+    },
+  );
+}
+
+/** Sessions across accessible agents (filter client-side by `agent_id`). */
+export function fetchNasikoObservabilitySessions(
+  authorization: string,
+  startTimeIso: string,
+): Promise<NasikoObservabilitySessionsResponse> {
+  return nasikoFetch<NasikoObservabilitySessionsResponse>(
+    "/api/v1/observability/session/list",
+    {
+      authorization,
+      searchParams: { start_time: startTimeIso },
+    },
+  );
+}
+
+export function fetchNasikoSessionDetails(
+  authorization: string,
+  sessionId: string,
+): Promise<unknown> {
+  return nasikoFetch(
+    `/api/v1/observability/session/${encodeURIComponent(sessionId)}`,
+    { authorization },
+  );
+}
+
+export function fetchNasikoTraceDetails(
+  authorization: string,
+  projectId: string,
+  traceId: string,
+): Promise<unknown> {
+  return nasikoFetch(
+    `/api/v1/observability/trace/${encodeURIComponent(projectId)}/${encodeURIComponent(traceId)}`,
+    { authorization },
+  );
+}

--- a/web/metrics-dashboard/lib/rollup.test.ts
+++ b/web/metrics-dashboard/lib/rollup.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateOrchestrationFromSessions,
+  aggregateQualityFromSessions,
+  buildAgentMetrics,
+  buildCostBreakdown,
+  buildSeries24h,
+  isSessionError,
+  rollupSessionCounts,
+} from "@/lib/rollup";
+import type {
+  NasikoAgentProjectStats,
+  NasikoObservabilitySession,
+} from "@/lib/types";
+
+const NOW = Date.parse("2026-05-16T14:30:00.000Z");
+
+describe("isSessionError", () => {
+  it("detects error text in last_output", () => {
+    expect(
+      isSessionError({
+        last_output: { value: "Sorry, an error occurred while processing" },
+      }),
+    ).toBe(true);
+  });
+
+  it("treats normal output as success", () => {
+    expect(
+      isSessionError({
+        last_output: { value: "Hola — translation complete." },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("rollupSessionCounts", () => {
+  it("sums traces into success and error buckets", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      { num_traces: 2, last_output: { value: "ok" } },
+      {
+        num_traces: 1,
+        last_output: { value: "Error code: 401 - Missing Authentication header" },
+      },
+    ];
+    expect(rollupSessionCounts(sessions)).toEqual({ success: 2, error: 1 });
+  });
+});
+
+describe("buildSeries24h", () => {
+  it("fills hourly buckets for session activity", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      {
+        start_time: "2026-05-16T13:15:00.000Z",
+        num_traces: 2,
+        trace_latency_ms_p50: 1000,
+        last_output: { value: "done" },
+      },
+      {
+        start_time: "2026-05-16T13:45:00.000Z",
+        num_traces: 1,
+        trace_latency_ms_p50: 2000,
+        last_output: { value: "Error: failed" },
+      },
+    ];
+
+    const series = buildSeries24h(sessions, 24, NOW);
+    expect(series).toHaveLength(24);
+
+    const active = series.filter((p) => p.success != null || p.error != null);
+    expect(active.length).toBeGreaterThanOrEqual(1);
+
+    const hour13 = series.find((p) => p.ts === "2026-05-16T13:00:00.000Z");
+    expect(hour13?.success).toBe(2);
+    expect(hour13?.error).toBe(1);
+    expect(hour13?.latency_ms).toBe(1500);
+  });
+});
+
+describe("buildAgentMetrics", () => {
+  it("merges stats and sessions into dashboard shape", () => {
+    const project: NasikoAgentProjectStats = {
+      trace_count: 4,
+      latency_ms_p50: 3595,
+      latency_ms_p99: 4977.8,
+    };
+    const sessions: NasikoObservabilitySession[] = [
+      {
+        agent_id: "a2a-translator",
+        start_time: "2026-05-16T13:00:00.000Z",
+        num_traces: 3,
+        trace_latency_ms_p50: 3000,
+        last_output: { value: "ok" },
+      },
+      {
+        agent_id: "a2a-translator",
+        start_time: "2026-05-16T13:30:00.000Z",
+        num_traces: 1,
+        trace_latency_ms_p50: 4000,
+        last_output: { value: "Error code: 500" },
+      },
+    ];
+
+    const metrics = buildAgentMetrics({
+      agentId: "a2a-translator",
+      window: "24h",
+      hours: 24,
+      project,
+      sessions,
+      uptimePct: 100,
+      uptimeMeta: {
+        successful_checks: 1,
+        recorded_checks: 1,
+        expected_checks_24h: 288,
+        poll_interval_minutes: 5,
+        current_health: true,
+      },
+      now: NOW,
+    });
+
+    expect(metrics.agent).toBe("a2a-translator");
+    expect(metrics.success).toBe(3);
+    expect(metrics.error).toBe(1);
+    expect(metrics.avg_latency_ms).toBe(3500);
+    expect(metrics.uptime_pct).toBe(100);
+    expect(metrics.series_24h).toHaveLength(24);
+    expect(metrics.source?.trace_count).toBe(4);
+  });
+});
+
+describe("aggregateQualityFromSessions (Tier B)", () => {
+  it("returns null when no annotations exist", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      { num_traces: 1, last_output: { value: "ok" } },
+    ];
+    expect(aggregateQualityFromSessions(sessions)).toBeNull();
+  });
+
+  it("averages mean_score across annotated sessions", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      {
+        num_traces: 1,
+        session_annotation_summaries: [
+          { name: "satisfaction", mean_score: 0.8, label_fractions: [] },
+        ],
+      },
+      {
+        num_traces: 1,
+        session_annotation_summaries: [
+          { name: "satisfaction", mean_score: 0.6, label_fractions: [] },
+        ],
+      },
+    ];
+    const quality = aggregateQualityFromSessions(sessions);
+    expect(quality?.mean_score).toBeCloseTo(0.7);
+    expect(quality?.sample_count).toBe(2);
+    expect(quality?.primary_annotation).toBe("satisfaction");
+  });
+
+  it("aggregates top label fractions sorted descending", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      {
+        num_traces: 1,
+        session_annotation_summaries: [
+          {
+            name: "feedback",
+            mean_score: null,
+            label_fractions: [
+              { label: "thumbs_up", fraction: 0.9 },
+              { label: "thumbs_down", fraction: 0.1 },
+            ],
+          },
+        ],
+      },
+      {
+        num_traces: 1,
+        session_annotation_summaries: [
+          {
+            name: "feedback",
+            mean_score: null,
+            label_fractions: [
+              { label: "thumbs_up", fraction: 0.7 },
+              { label: "thumbs_down", fraction: 0.3 },
+            ],
+          },
+        ],
+      },
+    ];
+    const quality = aggregateQualityFromSessions(sessions);
+    expect(quality?.top_labels[0]).toEqual({
+      label: "thumbs_up",
+      fraction: 0.8,
+    });
+    expect(quality?.top_labels[1].label).toBe("thumbs_down");
+  });
+});
+
+describe("aggregateOrchestrationFromSessions (Tier B)", () => {
+  it("returns null avg when no traces in window", () => {
+    const sessions: NasikoObservabilitySession[] = [{ num_traces: 0 }];
+    const out = aggregateOrchestrationFromSessions(sessions);
+    expect(out.avg_traces_per_session).toBeNull();
+    expect(out.total_sessions).toBe(0);
+  });
+
+  it("averages num_traces over sessions that have traces", () => {
+    const sessions: NasikoObservabilitySession[] = [
+      { num_traces: 4 },
+      { num_traces: 2 },
+      { num_traces: 0 }, // ignored
+    ];
+    const out = aggregateOrchestrationFromSessions(sessions);
+    expect(out.avg_traces_per_session).toBe(3);
+    expect(out.total_sessions).toBe(2);
+    expect(out.total_traces).toBe(6);
+  });
+});
+
+describe("buildCostBreakdown (Tier B)", () => {
+  it("returns null when no cost fields are present", () => {
+    expect(buildCostBreakdown({ cost_summary: {} })).toBeNull();
+  });
+
+  it("preserves prompt / completion / total", () => {
+    const out = buildCostBreakdown({
+      cost_summary: {
+        prompt: { cost: 0.012 },
+        completion: { cost: 0.005 },
+        total: { cost: 0.017 },
+      },
+    });
+    expect(out).toEqual({
+      prompt_usd: 0.012,
+      completion_usd: 0.005,
+      total_usd: 0.017,
+    });
+  });
+
+  it("infers total from prompt + completion when missing", () => {
+    const out = buildCostBreakdown({
+      cost_summary: { prompt: { cost: 0.01 }, completion: { cost: 0.02 } },
+    });
+    expect(out?.total_usd).toBeCloseTo(0.03);
+  });
+});
+
+describe("buildAgentMetrics — Tier B fields", () => {
+  it("includes quality / orchestration / cost_breakdown when data exists", () => {
+    const project: NasikoAgentProjectStats = {
+      trace_count: 2,
+      latency_ms_p50: 1000,
+      latency_ms_p99: 2000,
+      cost_summary: {
+        prompt: { cost: 0.01 },
+        completion: { cost: 0.005 },
+        total: { cost: 0.015 },
+      },
+    };
+    const sessions: NasikoObservabilitySession[] = [
+      {
+        agent_id: "a2a-translator",
+        start_time: "2026-05-16T13:00:00.000Z",
+        num_traces: 3,
+        trace_latency_ms_p50: 1100,
+        last_output: { value: "ok" },
+        session_annotation_summaries: [
+          {
+            name: "satisfaction",
+            mean_score: 0.9,
+            label_fractions: [{ label: "thumbs_up", fraction: 1.0 }],
+          },
+        ],
+      },
+    ];
+
+    const metrics = buildAgentMetrics({
+      agentId: "a2a-translator",
+      window: "24h",
+      hours: 24,
+      project,
+      sessions,
+      uptimePct: 100,
+      now: NOW,
+    });
+
+    expect(metrics.source?.quality?.mean_score).toBeCloseTo(0.9);
+    expect(metrics.source?.quality?.top_labels[0].label).toBe("thumbs_up");
+    expect(metrics.source?.orchestration?.avg_traces_per_session).toBe(3);
+    expect(metrics.source?.cost_breakdown?.prompt_usd).toBeCloseTo(0.01);
+    expect(metrics.source?.cost_breakdown?.completion_usd).toBeCloseTo(0.005);
+  });
+
+  it("omits Tier B blocks gracefully when no annotations or sessions", () => {
+    const metrics = buildAgentMetrics({
+      agentId: "a2a-translator",
+      window: "24h",
+      hours: 24,
+      project: { trace_count: 0 },
+      sessions: [],
+      uptimePct: null,
+      now: NOW,
+    });
+    expect(metrics.source?.quality).toBeUndefined();
+    expect(metrics.source?.orchestration).toBeUndefined();
+    expect(metrics.source?.cost_breakdown).toBeUndefined();
+  });
+});

--- a/web/metrics-dashboard/lib/rollup.ts
+++ b/web/metrics-dashboard/lib/rollup.ts
@@ -1,0 +1,349 @@
+/**
+ * B5: Roll up Phoenix sessions + project stats into dashboard KPIs and hourly series.
+ */
+
+import type {
+  AgentMetricsResponse,
+  MetricsHourlyPoint,
+  MetricsSourceMeta,
+  NasikoAgentProjectStats,
+  NasikoObservabilitySession,
+} from "@/lib/types";
+
+const ERROR_OUTPUT_PATTERN =
+  /\b(error|401|403|500|failed|failure|invalid api key|rate limit)\b|sorry,\s*an error|error occurred while processing|error code:/i;
+
+export function hourStartIso(tsMs: number): string {
+  const d = new Date(tsMs);
+  d.setUTCMinutes(0, 0, 0);
+  return d.toISOString();
+}
+
+export function buildHourlyBuckets(hours: number, now = Date.now()): string[] {
+  const keys: string[] = [];
+  for (let i = hours - 1; i >= 0; i--) {
+    keys.push(hourStartIso(now - i * 60 * 60 * 1000));
+  }
+  return keys;
+}
+
+function sessionOutputText(session: NasikoObservabilitySession): string {
+  const raw = session.last_output;
+  if (typeof raw === "string") {
+    return raw;
+  }
+  return raw?.value ?? "";
+}
+
+export function isSessionError(session: NasikoObservabilitySession): boolean {
+  const output = sessionOutputText(session);
+  if (typeof output === "string" && ERROR_OUTPUT_PATTERN.test(output)) {
+    return true;
+  }
+  const summaries = session.session_annotation_summaries ?? [];
+  for (const summary of summaries) {
+    const name = (summary.name ?? "").toLowerCase();
+    if (name.includes("error") || name.includes("fail")) {
+      return true;
+    }
+    for (const lf of summary.label_fractions ?? []) {
+      const label = (lf.label ?? "").toLowerCase();
+      if (label.includes("error") || label.includes("fail")) {
+        return (lf.fraction ?? 0) > 0.5;
+      }
+    }
+  }
+  return false;
+}
+
+export function parseSessionStartMs(session: NasikoObservabilitySession): number | null {
+  const raw = session.start_time;
+  if (!raw) {
+    return null;
+  }
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export type RollupCounts = { success: number; error: number };
+
+export function rollupSessionCounts(
+  sessions: NasikoObservabilitySession[],
+): RollupCounts {
+  let success = 0;
+  let error = 0;
+  for (const session of sessions) {
+    const traces = session.num_traces ?? 0;
+    if (traces <= 0) {
+      continue;
+    }
+    if (isSessionError(session)) {
+      error += traces;
+    } else {
+      success += traces;
+    }
+  }
+  return { success, error };
+}
+
+export function buildSeries24h(
+  sessions: NasikoObservabilitySession[],
+  hours: number,
+  now = Date.now(),
+): MetricsHourlyPoint[] {
+  const bucketKeys = buildHourlyBuckets(hours, now);
+  const buckets = new Map<
+    string,
+    { latencySum: number; latencyN: number; success: number; error: number }
+  >();
+
+  for (const key of bucketKeys) {
+    buckets.set(key, { latencySum: 0, latencyN: 0, success: 0, error: 0 });
+  }
+
+  const windowStart = now - hours * 60 * 60 * 1000;
+  const windowEnd = now;
+
+  for (const session of sessions) {
+    const startMs = parseSessionStartMs(session);
+    if (startMs == null || startMs < windowStart || startMs > windowEnd) {
+      continue;
+    }
+    const key = hourStartIso(startMs);
+    const bucket = buckets.get(key);
+    if (!bucket) {
+      continue;
+    }
+
+    const traces = session.num_traces ?? 0;
+    const failed = isSessionError(session);
+    if (failed) {
+      bucket.error += traces;
+    } else {
+      bucket.success += traces;
+    }
+
+    const latency = session.trace_latency_ms_p50;
+    if (latency != null && Number.isFinite(latency) && traces > 0) {
+      bucket.latencySum += latency;
+      bucket.latencyN += 1;
+    }
+  }
+
+  return bucketKeys.map((ts) => {
+    const b = buckets.get(ts)!;
+    const hasActivity = b.success > 0 || b.error > 0;
+    return {
+      ts,
+      latency_ms:
+        b.latencyN > 0 ? Math.round(b.latencySum / b.latencyN) : null,
+      success: hasActivity ? b.success : null,
+      error: hasActivity ? b.error : null,
+    };
+  });
+}
+
+/**
+ * Tier B — Aggregate session annotation summaries (mean_score + label_fractions)
+ * across the window. Picks the first annotation stream that yields a score and
+ * sticks with it (mixing rubrics is meaningless). Returns null mean_score
+ * when no sessions in the window have annotations.
+ */
+export function aggregateQualityFromSessions(
+  sessions: NasikoObservabilitySession[],
+): NonNullable<MetricsSourceMeta["quality"]> | null {
+  let primary: string | null = null;
+  let scoreSum = 0;
+  let scoreN = 0;
+  const labelTotals = new Map<string, { fractionSum: number; n: number }>();
+
+  for (const session of sessions) {
+    const summaries = session.session_annotation_summaries ?? [];
+    if (summaries.length === 0) continue;
+
+    // Lock onto the first annotation we see that produces a numeric score.
+    type Summary = (typeof summaries)[number];
+    let chosen: Summary | null = primary
+      ? summaries.find((s) => s.name === primary) ?? null
+      : null;
+    if (!chosen) {
+      chosen =
+        summaries.find(
+          (s) =>
+            typeof s.mean_score === "number" && Number.isFinite(s.mean_score),
+        ) ?? summaries[0] ?? null;
+      if (chosen?.name) {
+        primary = chosen.name;
+      }
+    }
+    if (!chosen) continue;
+
+    if (
+      typeof chosen.mean_score === "number" &&
+      Number.isFinite(chosen.mean_score)
+    ) {
+      scoreSum += chosen.mean_score;
+      scoreN += 1;
+    }
+
+    for (const lf of chosen.label_fractions ?? []) {
+      const label = (lf.label ?? "").trim();
+      const fraction = lf.fraction ?? 0;
+      if (!label || !Number.isFinite(fraction)) continue;
+      const cur = labelTotals.get(label) ?? { fractionSum: 0, n: 0 };
+      cur.fractionSum += fraction;
+      cur.n += 1;
+      labelTotals.set(label, cur);
+    }
+  }
+
+  if (scoreN === 0 && labelTotals.size === 0) {
+    return null;
+  }
+
+  const top_labels = Array.from(labelTotals.entries())
+    .map(([label, { fractionSum, n }]) => ({
+      label,
+      fraction: n > 0 ? fractionSum / n : 0,
+    }))
+    .sort((a, b) => b.fraction - a.fraction)
+    .slice(0, 4);
+
+  return {
+    mean_score: scoreN > 0 ? scoreSum / scoreN : null,
+    sample_count: scoreN,
+    top_labels,
+    primary_annotation: primary,
+  };
+}
+
+/**
+ * Tier B — Orchestration depth: mean traces-per-session in the window.
+ * Returns null when no sessions had num_traces > 0 (avoids divide-by-zero
+ * and meaningless 0.0 readings).
+ */
+export function aggregateOrchestrationFromSessions(
+  sessions: NasikoObservabilitySession[],
+): NonNullable<MetricsSourceMeta["orchestration"]> {
+  let totalSessions = 0;
+  let totalTraces = 0;
+  for (const session of sessions) {
+    const traces = session.num_traces ?? 0;
+    if (traces <= 0) continue;
+    totalSessions += 1;
+    totalTraces += traces;
+  }
+  return {
+    avg_traces_per_session:
+      totalSessions > 0 ? totalTraces / totalSessions : null,
+    total_sessions: totalSessions,
+    total_traces: totalTraces,
+  };
+}
+
+/**
+ * Tier B — Prompt vs completion cost split from Phoenix `cost_summary`.
+ * Returns `null` when neither side reported a number — useful for hiding the
+ * mini-viz cleanly.
+ */
+export function buildCostBreakdown(
+  project: NasikoAgentProjectStats,
+): NonNullable<MetricsSourceMeta["cost_breakdown"]> | null {
+  const prompt = project.cost_summary?.prompt?.cost ?? null;
+  const completion = project.cost_summary?.completion?.cost ?? null;
+  const total = project.cost_summary?.total?.cost ?? null;
+  const numeric = (v: number | null): number | null =>
+    typeof v === "number" && Number.isFinite(v) ? v : null;
+  const promptN = numeric(prompt);
+  const completionN = numeric(completion);
+  const totalN = numeric(total);
+  if (promptN == null && completionN == null && totalN == null) {
+    return null;
+  }
+  let totalUsd: number | null = totalN;
+  if (totalUsd == null) {
+    const inferred = (promptN ?? 0) + (completionN ?? 0);
+    totalUsd = inferred > 0 ? inferred : null;
+  }
+  return {
+    prompt_usd: promptN,
+    completion_usd: completionN,
+    total_usd: totalUsd,
+  };
+}
+
+export function averageLatencyFromSessions(
+  sessions: NasikoObservabilitySession[],
+): number | null {
+  let sum = 0;
+  let n = 0;
+  for (const session of sessions) {
+    const latency = session.trace_latency_ms_p50;
+    if (latency != null && Number.isFinite(latency) && (session.num_traces ?? 0) > 0) {
+      sum += latency;
+      n += 1;
+    }
+  }
+  if (n === 0) {
+    return null;
+  }
+  return Math.round(sum / n);
+}
+
+export type BuildAgentMetricsInput = {
+  agentId: string;
+  window: string;
+  hours: number;
+  project: NasikoAgentProjectStats;
+  sessions: NasikoObservabilitySession[];
+  uptimePct: number | null;
+  uptimeMeta?: MetricsSourceMeta["uptime"];
+  now?: number;
+};
+
+export function buildAgentMetrics(input: BuildAgentMetricsInput): AgentMetricsResponse {
+  const { agentId, window, hours, project, sessions, uptimePct, now = Date.now() } =
+    input;
+
+  const sessionCounts = rollupSessionCounts(sessions);
+  const traceCount = project.trace_count ?? 0;
+  const success =
+    sessionCounts.success + sessionCounts.error > 0
+      ? sessionCounts.success
+      : traceCount;
+  const error =
+    sessionCounts.success + sessionCounts.error > 0 ? sessionCounts.error : 0;
+
+  const avgFromSessions = averageLatencyFromSessions(sessions);
+  const avgLatencyMs =
+    avgFromSessions ??
+    (project.latency_ms_p50 != null && Number.isFinite(project.latency_ms_p50)
+      ? Math.round(project.latency_ms_p50)
+      : null);
+
+  const quality = aggregateQualityFromSessions(sessions);
+  const orchestration = aggregateOrchestrationFromSessions(sessions);
+  const costBreakdown = buildCostBreakdown(project);
+
+  return {
+    agent: agentId,
+    window,
+    avg_latency_ms: avgLatencyMs,
+    success,
+    error,
+    uptime_pct: uptimePct,
+    series_24h: buildSeries24h(sessions, hours, now),
+    source: {
+      trace_count: traceCount,
+      latency_ms_p50: project.latency_ms_p50 ?? null,
+      latency_ms_p99: project.latency_ms_p99 ?? null,
+      project_id: project.id ?? null,
+      cost_usd: project.cost_summary?.total?.cost ?? null,
+      session_count: sessions.length,
+      ...(input.uptimeMeta ? { uptime: input.uptimeMeta } : {}),
+      ...(quality ? { quality } : {}),
+      ...(orchestration.total_sessions > 0 ? { orchestration } : {}),
+      ...(costBreakdown ? { cost_breakdown: costBreakdown } : {}),
+    },
+  };
+}

--- a/web/metrics-dashboard/lib/session-filters.test.ts
+++ b/web/metrics-dashboard/lib/session-filters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { filterSessionRows } from "@/lib/session-filters";
+import type { MetricsSessionRow } from "@/lib/types";
+
+const rows: MetricsSessionRow[] = [
+  {
+    session_id: "a",
+    start_time: "2026-05-17T10:00:00.000Z",
+    num_traces: 1,
+    latency_ms_p50: 100,
+    status: "ok",
+    preview: "ok",
+  },
+  {
+    session_id: "b",
+    start_time: "2026-05-17T11:00:00.000Z",
+    num_traces: 1,
+    latency_ms_p50: 200,
+    status: "error",
+    preview: "failed",
+  },
+];
+
+describe("filterSessionRows", () => {
+  it("filters by status", () => {
+    expect(filterSessionRows(rows, { status: "error" })).toHaveLength(1);
+    expect(filterSessionRows(rows, { status: "error" })[0].session_id).toBe("b");
+  });
+
+  it("filters by time range", () => {
+    const startMs = Date.parse("2026-05-17T10:30:00.000Z");
+    const endMs = Date.parse("2026-05-17T10:30:00.000Z");
+    expect(filterSessionRows(rows, { startMs, endMs })).toHaveLength(0);
+  });
+});

--- a/web/metrics-dashboard/lib/session-filters.ts
+++ b/web/metrics-dashboard/lib/session-filters.ts
@@ -1,0 +1,52 @@
+import type { MetricsSessionRow } from "@/lib/types";
+
+export type SessionStatusFilter = "all" | "ok" | "error";
+
+export function filterSessionRows(
+  rows: MetricsSessionRow[],
+  options: {
+    status?: SessionStatusFilter;
+    startMs?: number;
+    endMs?: number;
+  },
+): MetricsSessionRow[] {
+  const { status = "all", startMs, endMs } = options;
+
+  return rows.filter((row) => {
+    if (status !== "all" && row.status !== status) {
+      return false;
+    }
+
+    if (startMs == null && endMs == null) {
+      return true;
+    }
+
+    const ms = row.start_time ? Date.parse(row.start_time) : NaN;
+    if (!Number.isFinite(ms)) {
+      return status === "all";
+    }
+    if (startMs != null && ms < startMs) {
+      return false;
+    }
+    if (endMs != null && ms > endMs) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function filterNasikoSessionsInRange<
+  T extends { start_time?: string | null },
+>(sessions: T[], startMs: number, endMs: number): T[] {
+  return sessions.filter((session) => {
+    const raw = session.start_time;
+    if (!raw) {
+      return false;
+    }
+    const ms = Date.parse(raw);
+    if (!Number.isFinite(ms)) {
+      return false;
+    }
+    return ms >= startMs && ms <= endMs;
+  });
+}

--- a/web/metrics-dashboard/lib/sessions.ts
+++ b/web/metrics-dashboard/lib/sessions.ts
@@ -1,0 +1,91 @@
+import { isSessionError, parseSessionStartMs } from "@/lib/rollup";
+import type {
+  MetricsSessionRow,
+  NasikoObservabilitySession,
+  SessionTraceRef,
+} from "@/lib/types";
+
+function sessionPreview(session: NasikoObservabilitySession): string | null {
+  const raw = session.last_output;
+  const text = typeof raw === "string" ? raw : raw?.value;
+  if (!text || typeof text !== "string") {
+    return null;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.length > 120 ? `${trimmed.slice(0, 117)}…` : trimmed;
+}
+
+export function toSessionRow(session: NasikoObservabilitySession): MetricsSessionRow | null {
+  const sessionId = session.session_id?.trim();
+  if (!sessionId) {
+    return null;
+  }
+
+  const errored = isSessionError(session);
+  const traces = session.num_traces ?? 0;
+
+  return {
+    session_id: sessionId,
+    start_time: session.start_time ?? null,
+    num_traces: traces,
+    latency_ms_p50: session.trace_latency_ms_p50 ?? null,
+    status: traces <= 0 ? "unknown" : errored ? "error" : "ok",
+    preview: sessionPreview(session),
+  };
+}
+
+export function normalizeSessions(
+  sessions: NasikoObservabilitySession[],
+  agentId: string,
+): MetricsSessionRow[] {
+  return sessions
+    .filter((s) => !s.agent_id || s.agent_id === agentId)
+    .map(toSessionRow)
+    .filter((row): row is MetricsSessionRow => row != null)
+    .sort((a, b) => {
+      const aMs = a.start_time ? Date.parse(a.start_time) : 0;
+      const bMs = b.start_time ? Date.parse(b.start_time) : 0;
+      return bMs - aMs;
+    });
+}
+
+export function extractSessionTraces(
+  traces: Array<Record<string, unknown>>,
+): SessionTraceRef[] {
+  const out: SessionTraceRef[] = [];
+  for (const trace of traces) {
+    const traceId =
+      (typeof trace.trace_id === "string" && trace.trace_id) ||
+      (typeof trace.traceId === "string" && trace.traceId);
+    if (!traceId) {
+      continue;
+    }
+    const rootSpan = trace.root_span as Record<string, unknown> | undefined;
+    const rootSpanAlt = trace.rootSpan as Record<string, unknown> | undefined;
+    const latency =
+      (rootSpan?.latency_ms as number | undefined) ??
+      (rootSpanAlt?.latencyMs as number | undefined) ??
+      null;
+    out.push({
+      id: typeof trace.id === "string" ? trace.id : undefined,
+      trace_id: traceId,
+      latency_ms: latency,
+    });
+  }
+  return out;
+}
+
+/** Prefer the most recent trace with the highest latency (usually the main request). */
+export function pickPrimaryTrace(traces: SessionTraceRef[]): SessionTraceRef | null {
+  if (traces.length === 0) {
+    return null;
+  }
+  return [...traces].sort(
+    (a, b) => (b.latency_ms ?? 0) - (a.latency_ms ?? 0),
+  )[0];
+}
+
+export { parseSessionStartMs };

--- a/web/metrics-dashboard/lib/time-range.ts
+++ b/web/metrics-dashboard/lib/time-range.ts
@@ -1,0 +1,116 @@
+/** Shared time-range helpers for metrics dashboard filters. */
+
+export type MetricsTimeRange = {
+  /** ISO UTC — Nasiko `start_time` query */
+  startTimeIso: string;
+  /** ISO UTC — client-side end bound (inclusive) */
+  endTimeIso: string;
+  startMs: number;
+  endMs: number;
+  hours: number;
+  /** Label for KPI footer, e.g. `custom` or `24h` */
+  window: string;
+};
+
+const MAX_RANGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function toDatetimeLocalValue(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+export function parseDatetimeLocal(value: string): Date | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const ms = Date.parse(trimmed);
+  if (!Number.isFinite(ms)) {
+    return null;
+  }
+  return new Date(ms);
+}
+
+export function defaultTimeRange(now = Date.now()): MetricsTimeRange {
+  return buildTimeRange(new Date(now - 24 * 60 * 60 * 1000), new Date(now));
+}
+
+export function buildTimeRange(from: Date, to: Date): MetricsTimeRange {
+  const startMs = from.getTime();
+  const endMs = to.getTime();
+  const hours = Math.max(1, Math.ceil((endMs - startMs) / (60 * 60 * 1000)));
+  return {
+    startTimeIso: from.toISOString(),
+    endTimeIso: to.toISOString(),
+    startMs,
+    endMs,
+    hours,
+    window: "custom",
+  };
+}
+
+export function presetTimeRange(
+  preset: "1h" | "24h" | "7d",
+  now = Date.now(),
+): MetricsTimeRange {
+  const to = new Date(now);
+  const ms =
+    preset === "1h"
+      ? 60 * 60 * 1000
+      : preset === "7d"
+        ? 7 * 24 * 60 * 60 * 1000
+        : 24 * 60 * 60 * 1000;
+  const range = buildTimeRange(new Date(now - ms), to);
+  return { ...range, window: preset };
+}
+
+export function parseTimeRangeQuery(
+  searchParams: URLSearchParams,
+  now = Date.now(),
+): MetricsTimeRange | { error: string } {
+  const startRaw = searchParams.get("startTime")?.trim();
+  const endRaw = searchParams.get("endTime")?.trim();
+
+  if (startRaw && endRaw) {
+    const from = new Date(startRaw);
+    const to = new Date(endRaw);
+    if (!Number.isFinite(from.getTime()) || !Number.isFinite(to.getTime())) {
+      return { error: "Invalid startTime or endTime" };
+    }
+    if (to.getTime() <= from.getTime()) {
+      return { error: "endTime must be after startTime" };
+    }
+    if (to.getTime() - from.getTime() > MAX_RANGE_MS) {
+      return { error: "Time range cannot exceed 7 days" };
+    }
+    return buildTimeRange(from, to);
+  }
+
+  const window = (searchParams.get("window") ?? "24h").trim().toLowerCase();
+  if (window === "1h") {
+    return presetTimeRange("1h", now);
+  }
+  if (window === "7d") {
+    return presetTimeRange("7d", now);
+  }
+  if (window === "24h") {
+    return { ...presetTimeRange("24h", now), window: "24h" };
+  }
+
+  return { error: `Unsupported window "${window}". Use 1h, 24h, 7d, or startTime/endTime.` };
+}
+
+export function timeRangeQueryString(range: MetricsTimeRange): string {
+  return `startTime=${encodeURIComponent(range.startTimeIso)}&endTime=${encodeURIComponent(range.endTimeIso)}`;
+}
+
+export function formatRangeLabel(range: MetricsTimeRange): string {
+  const fmt = (ms: number) =>
+    new Date(ms).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  return `${fmt(range.startMs)} – ${fmt(range.endMs)}`;
+}

--- a/web/metrics-dashboard/lib/trace-graph.test.ts
+++ b/web/metrics-dashboard/lib/trace-graph.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { spansToFlowGraph } from "@/lib/trace-graph";
+
+describe("spansToFlowGraph", () => {
+  it("builds nodes and parent-child edges", () => {
+    const { nodes, edges, truncated } = spansToFlowGraph([
+      {
+        id: "root",
+        span_id: "root",
+        name: "POST /",
+        latency_ms: 100,
+        status_code: "OK",
+        children: [
+          {
+            id: "child",
+            span_id: "child",
+            name: "llm",
+            latency_ms: 80,
+            status_code: "OK",
+            children: [],
+          },
+        ],
+      },
+    ]);
+
+    expect(truncated).toBe(false);
+    expect(nodes).toHaveLength(2);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe("root");
+    expect(edges[0].target).toBe("child");
+  });
+
+  it("truncates very large trees", () => {
+    const deep: Parameters<typeof spansToFlowGraph>[0] = [
+      {
+        id: "r",
+        span_id: "r",
+        name: "root",
+        children: [],
+      },
+    ];
+    let current = deep[0];
+    for (let i = 0; i < 80; i++) {
+      const child = {
+        id: `c${i}`,
+        span_id: `c${i}`,
+        name: `span-${i}`,
+        children: [] as never[],
+      };
+      current.children = [child];
+      current = child;
+    }
+
+    const { truncated, nodes } = spansToFlowGraph(deep, 10);
+    expect(truncated).toBe(true);
+    expect(nodes.length).toBeLessThanOrEqual(10);
+  });
+});

--- a/web/metrics-dashboard/lib/trace-graph.ts
+++ b/web/metrics-dashboard/lib/trace-graph.ts
@@ -1,0 +1,123 @@
+import type {
+  TraceGraphEdge,
+  TraceGraphNode,
+  TraceSpanNode,
+} from "@/lib/types";
+
+const MAX_SPANS = 60;
+
+function spanNodeId(span: TraceSpanNode, fallback: string): string {
+  return span.span_id ?? span.id ?? fallback;
+}
+
+function statusTone(status: string | null | undefined): string {
+  const code = (status ?? "").toUpperCase();
+  if (code === "ERROR" || code === "STATUS_CODE_ERROR") {
+    return "error";
+  }
+  if (code === "OK" || code === "STATUS_CODE_OK") {
+    return "ok";
+  }
+  return "neutral";
+}
+
+type WalkState = {
+  nodes: TraceGraphNode[];
+  edges: TraceGraphEdge[];
+  row: number;
+  count: number;
+  maxSpans: number;
+  truncated: boolean;
+};
+
+function walkSpan(
+  span: TraceSpanNode,
+  depth: number,
+  state: WalkState,
+  parentId?: string,
+): void {
+  if (state.count >= state.maxSpans) {
+    state.truncated = true;
+    return;
+  }
+
+  const id = spanNodeId(span, `span-${state.count}`);
+  state.count += 1;
+  state.row += 1;
+
+  state.nodes.push({
+    id,
+    position: { x: depth * 240, y: state.row * 72 },
+    data: {
+      label: span.name?.trim() || span.span_kind || "span",
+      latency_ms:
+        span.latency_ms != null && Number.isFinite(span.latency_ms)
+          ? span.latency_ms
+          : null,
+      status_code: span.status_code ?? null,
+      span_kind: span.span_kind ?? null,
+    },
+  });
+
+  if (parentId) {
+    state.edges.push({
+      id: `${parentId}->${id}`,
+      source: parentId,
+      target: id,
+    });
+  }
+
+  for (const child of span.children ?? []) {
+    walkSpan(child, depth + 1, state, id);
+    if (state.truncated) {
+      break;
+    }
+  }
+}
+
+export function spansToFlowGraph(
+  roots: TraceSpanNode[],
+  maxSpans = MAX_SPANS,
+): { nodes: TraceGraphNode[]; edges: TraceGraphEdge[]; truncated: boolean } {
+  const state: WalkState = {
+    nodes: [],
+    edges: [],
+    row: 0,
+    count: 0,
+    maxSpans,
+    truncated: false,
+  };
+
+  for (const root of roots) {
+    walkSpan(root, 0, state);
+    if (state.count >= maxSpans) {
+      state.truncated = true;
+      break;
+    }
+  }
+
+  return {
+    nodes: state.nodes,
+    edges: state.edges,
+    truncated: state.truncated,
+  };
+}
+
+export function parseTraceSpans(tracePayload: unknown): TraceSpanNode[] {
+  if (!tracePayload || typeof tracePayload !== "object") {
+    return [];
+  }
+  const data = tracePayload as Record<string, unknown>;
+  const inner = data.data as Record<string, unknown> | undefined;
+  const trace = (inner?.trace ?? data.trace) as Record<string, unknown> | undefined;
+  if (!trace) {
+    return [];
+  }
+  const spans = trace.spans;
+  if (Array.isArray(spans)) {
+    return spans as TraceSpanNode[];
+  }
+  return [];
+}
+
+export { statusTone, MAX_SPANS };

--- a/web/metrics-dashboard/lib/trace-pipeline.test.ts
+++ b/web/metrics-dashboard/lib/trace-pipeline.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySpan,
+  isInfrastructureSpan,
+  spansToPipelineGraph,
+} from "@/lib/trace-pipeline";
+
+describe("trace-pipeline", () => {
+  it("treats JSON-RPC handlers as infrastructure", () => {
+    const span = {
+      id: "1",
+      name: "a2a.server.request_handlers.jsonrpc_handler.JSONRPCHandler.on_message_send",
+    };
+    expect(isInfrastructureSpan(span)).toBe(true);
+    expect(classifySpan(span)).toBe("step");
+  });
+
+  it("classifies ChatCompletion as LLM", () => {
+    expect(
+      classifySpan({ id: "1", name: "ChatCompletion", span_kind: "LLM" }),
+    ).toBe("llm");
+  });
+
+  it("builds user → OpenAI pipeline only", () => {
+    const { nodes, edges } = spansToPipelineGraph(
+      [
+        {
+          id: "root",
+          span_id: "root",
+          name: "a2a.server.request_handlers.jsonrpc_handler.JSONRPCHandler.on_message_send",
+          status_code: "OK",
+          latency_ms: 1900,
+          children: [
+            {
+              id: "llm",
+              span_id: "llm",
+              name: "ChatCompletion",
+              span_kind: "LLM",
+              status_code: "OK",
+              latency_ms: 1800,
+              children: [
+                {
+                  id: "cb",
+                  span_id: "cb",
+                  name: "a2a.server.events.event_consumer.EventConsumer.agent_task_callback",
+                  status_code: "OK",
+                  latency_ms: 0,
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      { userPreview: "Translate hello to French" },
+    );
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].data.node_kind).toBe("user");
+    expect(nodes[0].data.label).toContain("Translate");
+    expect(nodes[1].data.node_kind).toBe("llm");
+    expect(nodes[1].data.label).toBe("OpenAI");
+    expect(nodes[1].data.subtitle).toBe("Chat completion");
+    expect(edges).toHaveLength(1);
+  });
+
+  it("marks error tone on failed LLM", () => {
+    const { nodes } = spansToPipelineGraph([
+      {
+        id: "llm",
+        span_id: "llm",
+        name: "ChatCompletion",
+        span_kind: "LLM",
+        status_code: "ERROR",
+        children: [],
+      },
+    ]);
+    expect(nodes.find((n) => n.data.node_kind === "llm")?.data.tone).toBe("error");
+  });
+});

--- a/web/metrics-dashboard/lib/trace-pipeline.ts
+++ b/web/metrics-dashboard/lib/trace-pipeline.ts
@@ -1,0 +1,256 @@
+import type {
+  TraceGraphEdge,
+  TraceGraphNode,
+  TraceSpanNode,
+} from "@/lib/types";
+
+export type WorkflowNodeKind = "user" | "llm" | "agent" | "tool" | "step";
+
+export type WorkflowNodeTone = "ok" | "error" | "neutral";
+
+const NODE_GAP_X = 240;
+
+/** Internal plumbing — hide from the n8n-style canvas. */
+export function isInfrastructureSpan(span: TraceSpanNode): boolean {
+  const name = (span.name ?? "").toLowerCase();
+  return (
+    /jsonrpc|event_consumer|request_handler|request_handlers|callback|middleware|\.on_message/i.test(
+      name,
+    ) || /a2a\.server\.|fastapi|starlette|uvicorn|http\.route/i.test(name)
+  );
+}
+
+export function classifySpan(span: TraceSpanNode): WorkflowNodeKind {
+  if (isInfrastructureSpan(span)) {
+    return "step";
+  }
+
+  const name = (span.name ?? "").toLowerCase();
+  const kind = (span.span_kind ?? "").toUpperCase();
+
+  if (
+    kind === "LLM" ||
+    /openai|gpt-|chat\.?completion|chatcompletion|langchain\.chat|llm/i.test(name)
+  ) {
+    return "llm";
+  }
+  if (kind === "TOOL" || /tool|function_call|mcp/i.test(name)) {
+    return "tool";
+  }
+  if (
+    kind === "CHAIN" ||
+    kind === "AGENT" ||
+    (/agent|chain|invoke|orchestrat/i.test(name) && !/handler/i.test(name))
+  ) {
+    return "agent";
+  }
+  if (/^user|^human|user_message|human_message/i.test(name)) {
+    return "user";
+  }
+  return "step";
+}
+
+export function spanTone(status: string | null | undefined): WorkflowNodeTone {
+  const code = (status ?? "").toUpperCase();
+  if (code === "ERROR" || code === "STATUS_CODE_ERROR") {
+    return "error";
+  }
+  if (code === "OK" || code === "STATUS_CODE_OK") {
+    return "ok";
+  }
+  return "neutral";
+}
+
+function flattenSpans(roots: TraceSpanNode[]): TraceSpanNode[] {
+  const out: TraceSpanNode[] = [];
+  const walk = (span: TraceSpanNode) => {
+    out.push(span);
+    for (const child of span.children ?? []) {
+      walk(child);
+    }
+  };
+  for (const root of roots) {
+    walk(root);
+  }
+  return out;
+}
+
+function pickBestSpan(
+  flat: TraceSpanNode[],
+  kind: WorkflowNodeKind,
+): TraceSpanNode | null {
+  const candidates = flat.filter(
+    (s) => classifySpan(s) === kind && !isInfrastructureSpan(s),
+  );
+  if (candidates.length === 0) {
+    return null;
+  }
+  return [...candidates].sort(
+    (a, b) => (b.latency_ms ?? 0) - (a.latency_ms ?? 0),
+  )[0];
+}
+
+export function shortLlmSubtitle(name: string | undefined): string {
+  const n = (name ?? "").trim();
+  if (!n) return "Model call";
+  if (/chatcompletion/i.test(n)) return "Chat completion";
+  if (/completion/i.test(n)) return "Completion";
+  const short = n.split(".").pop() ?? n;
+  return short.length > 28 ? `${short.slice(0, 25)}…` : short;
+}
+
+function spanSubtitle(
+  span: TraceSpanNode,
+  kind: WorkflowNodeKind,
+): string | undefined {
+  if (kind === "llm") {
+    return shortLlmSubtitle(span.name);
+  }
+  if (kind === "agent") {
+    return "Agent orchestration";
+  }
+  if (kind === "tool") {
+    const n = span.name?.trim();
+    return n ? (n.length > 32 ? `${n.slice(0, 29)}…` : n) : "Tool call";
+  }
+  const sk = span.span_kind?.trim();
+  if (!sk || sk.toLowerCase() === "unknown") {
+    return undefined;
+  }
+  return sk;
+}
+
+function createUserNode(preview: string | null | undefined): TraceGraphNode {
+  const text = preview?.trim();
+  return {
+    id: "pipeline-user",
+    position: { x: 0, y: 48 },
+    data: {
+      label: text
+        ? text.length > 42
+          ? `${text.slice(0, 39)}…`
+          : text
+        : "User prompt",
+      latency_ms: null,
+      status_code: "OK",
+      span_kind: "USER",
+      node_kind: "user",
+      tone: "ok",
+      subtitle: "Incoming message",
+    },
+  };
+}
+
+function createStepNode(
+  span: TraceSpanNode,
+  kind: WorkflowNodeKind,
+  index: number,
+): TraceGraphNode {
+  const tone = spanTone(span.status_code);
+  const label =
+    kind === "llm"
+      ? "OpenAI"
+      : kind === "agent"
+        ? "Agent"
+        : kind === "tool"
+          ? "Tool"
+          : "Step";
+
+  return {
+    id: span.span_id ?? span.id ?? `pipeline-${kind}-${index}`,
+    position: { x: index * NODE_GAP_X, y: 48 },
+    data: {
+      label,
+      latency_ms:
+        span.latency_ms != null && Number.isFinite(span.latency_ms)
+          ? span.latency_ms
+          : null,
+      status_code: span.status_code ?? null,
+      span_kind: span.span_kind ?? null,
+      node_kind: kind,
+      tone,
+      subtitle: spanSubtitle(span, kind),
+    },
+  };
+}
+
+/**
+ * Curated left-to-right pipeline: User prompt → OpenAI → (optional Agent/Tool).
+ * Skips JSON-RPC handlers, callbacks, and other internal spans.
+ */
+export function spansToPipelineGraph(
+  roots: TraceSpanNode[],
+  options?: { userPreview?: string | null; maxSteps?: number },
+): { nodes: TraceGraphNode[]; edges: TraceGraphEdge[]; truncated: boolean } {
+  const flat = flattenSpans(roots);
+  const truncated = flat.length > (options?.maxSteps ?? 14);
+
+  const nodes: TraceGraphNode[] = [createUserNode(options?.userPreview)];
+
+  const llm = pickBestSpan(flat, "llm");
+  if (llm) {
+    nodes.push(createStepNode(llm, "llm", nodes.length));
+  }
+
+  const agent = pickBestSpan(flat, "agent");
+  if (agent && agent !== llm) {
+    nodes.push(createStepNode(agent, "agent", nodes.length));
+  }
+
+  const tool = pickBestSpan(flat, "tool");
+  if (tool && tool !== llm && tool !== agent) {
+    nodes.push(createStepNode(tool, "tool", nodes.length));
+  }
+
+  const anyError = flat.some(
+    (s) =>
+      spanTone(s.status_code) === "error" && classifySpan(s) !== "step",
+  );
+  if (anyError && nodes[nodes.length - 1]?.data.tone !== "error") {
+    const failed = flat.find(
+      (s) =>
+        spanTone(s.status_code) === "error" &&
+        (classifySpan(s) === "llm" ||
+          classifySpan(s) === "agent" ||
+          classifySpan(s) === "tool"),
+    );
+    if (failed) {
+      const kind = classifySpan(failed);
+      const existing = nodes.find((n) => n.data.node_kind === kind);
+      if (existing) {
+        existing.data.tone = "error";
+      }
+    } else {
+      nodes[nodes.length - 1].data.tone = "error";
+    }
+  }
+
+  const edges: TraceGraphEdge[] = [];
+  for (let i = 0; i < nodes.length; i++) {
+    nodes[i].position = { x: i * NODE_GAP_X, y: 48 };
+    if (i > 0) {
+      edges.push({
+        id: `edge-${i}`,
+        source: nodes[i - 1].id,
+        target: nodes[i].id,
+      });
+    }
+  }
+
+  return { nodes, edges, truncated };
+}
+
+export function defaultLabel(kind: WorkflowNodeKind): string {
+  switch (kind) {
+    case "user":
+      return "User prompt";
+    case "llm":
+      return "OpenAI";
+    case "agent":
+      return "Agent";
+    case "tool":
+      return "Tool";
+    default:
+      return "Step";
+  }
+}

--- a/web/metrics-dashboard/lib/types.ts
+++ b/web/metrics-dashboard/lib/types.ts
@@ -1,0 +1,244 @@
+/** Shapes from Nasiko `GET /api/v1/registry/user/agents` (SimpleUserAgentsResponse). */
+
+export type NasikoSimpleUserAgent = {
+  agent_id: string;
+  name: string;
+  icon_url?: string | null;
+  tags?: string[];
+  description?: string | null;
+};
+
+export type NasikoSimpleUserAgentsResponse = {
+  data: NasikoSimpleUserAgent[];
+  status_code: number;
+  message: string;
+};
+
+/** Normalized agent for the metrics UI dropdown. */
+export type MetricsAgentOption = {
+  agentId: string;
+  name: string;
+  description?: string | null;
+  tags: string[];
+};
+
+/** Nasiko `GET /api/v1/observability/agent/{id}/stats` → `data.project`. */
+export type NasikoAgentProjectStats = {
+  trace_count?: number;
+  latency_ms_p50?: number | null;
+  latency_ms_p99?: number | null;
+  cost_summary?: {
+    total?: { cost?: number };
+    prompt?: { cost?: number };
+    completion?: { cost?: number };
+  };
+  span_annotation_names?: string[];
+  id?: string;
+};
+
+export type NasikoAgentStatsResponse = {
+  data: {
+    project: NasikoAgentProjectStats;
+  };
+};
+
+/** Nasiko `GET /api/v1/observability/session/list` session node (snake_case). */
+export type NasikoObservabilitySession = {
+  agent_id?: string;
+  session_id?: string;
+  num_traces?: number;
+  start_time?: string;
+  end_time?: string;
+  trace_latency_ms_p50?: number | null;
+  trace_latency_ms_p99?: number | null;
+  last_output?: { value?: string } | string | null;
+  session_annotation_summaries?: Array<{
+    name?: string;
+    mean_score?: number | null;
+    label_fractions?: Array<{ label?: string; fraction?: number }>;
+  }>;
+};
+
+export type NasikoObservabilitySessionsResponse = {
+  data: {
+    sessions: NasikoObservabilitySession[];
+    total_agents?: number;
+    successful_agents?: number;
+  };
+};
+
+export type MetricsSourceMeta = {
+  trace_count: number;
+  latency_ms_p50: number | null;
+  latency_ms_p99: number | null;
+  project_id?: string | null;
+  cost_usd?: number | null;
+  session_count?: number;
+  uptime?: {
+    successful_checks: number;
+    recorded_checks: number;
+    expected_checks_24h: number;
+    poll_interval_minutes: number;
+    current_health: boolean;
+  };
+  /**
+   * Tier B — User-feedback / quality scores aggregated from
+   * `session_annotation_summaries[*].mean_score` (e.g. thumbs/ratings).
+   * `null` mean_score = no annotated sessions in window.
+   */
+  quality?: {
+    mean_score: number | null;
+    sample_count: number;
+    /**
+     * Top label fractions across all annotated sessions in the window
+     * (sorted descending by fraction; capped to 4 entries).
+     */
+    top_labels: Array<{ label: string; fraction: number }>;
+    /**
+     * The annotation name we surfaced (first that produced a score).
+     * Hint for the UI when there are multiple annotation streams.
+     */
+    primary_annotation?: string | null;
+  };
+  /**
+   * Tier B — Orchestration depth: how many spans/traces per user request,
+   * a proxy for tool-call complexity. From `session.num_traces`.
+   */
+  orchestration?: {
+    avg_traces_per_session: number | null;
+    total_sessions: number;
+    total_traces: number;
+  };
+  /**
+   * Tier B — Prompt vs completion cost split from Phoenix `cost_summary`.
+   * Either half may be null if Phoenix didn't report it.
+   */
+  cost_breakdown?: {
+    prompt_usd: number | null;
+    completion_usd: number | null;
+    total_usd: number | null;
+  };
+};
+
+export type MetricsHourlyPoint = {
+  ts: string;
+  latency_ms: number | null;
+  success: number | null;
+  error: number | null;
+};
+
+/** Dashboard JSON from `GET /api/metrics` (B4 contract; B5–B6 fill series/uptime). */
+export type AgentMetricsResponse = {
+  agent: string;
+  window: string;
+  avg_latency_ms: number | null;
+  success: number;
+  error: number;
+  uptime_pct: number | null;
+  series_24h: MetricsHourlyPoint[];
+  source?: MetricsSourceMeta;
+  /** True when Phoenix project missing or no traces in window. */
+  no_data?: boolean;
+  message?: string;
+};
+
+/** Row for sessions table (from `/api/sessions`). */
+export type MetricsSessionRow = {
+  session_id: string;
+  start_time: string | null;
+  num_traces: number;
+  latency_ms_p50: number | null;
+  status: "ok" | "error" | "unknown";
+  preview: string | null;
+};
+
+export type SessionsListResponse = {
+  agent: string;
+  window: string;
+  sessions: MetricsSessionRow[];
+};
+
+export type SessionTraceRef = {
+  id?: string;
+  trace_id: string;
+  latency_ms?: number | null;
+};
+
+export type SessionDetailResponse = {
+  session_id: string;
+  num_traces: number;
+  traces: SessionTraceRef[];
+  project_id: string | null;
+};
+
+export type TraceSpanNode = {
+  id: string;
+  span_id?: string;
+  name?: string;
+  span_kind?: string;
+  status_code?: string;
+  latency_ms?: number | null;
+  children?: TraceSpanNode[];
+};
+
+export type TraceGraphNode = {
+  id: string;
+  position: { x: number; y: number };
+  data: {
+    label: string;
+    latency_ms: number | null;
+    status_code: string | null;
+    span_kind: string | null;
+    /** n8n-style workflow node type for the trace canvas */
+    node_kind?: "user" | "llm" | "agent" | "tool" | "step";
+    tone?: "ok" | "error" | "neutral";
+    subtitle?: string;
+  };
+};
+
+export type TraceGraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+};
+
+export type TraceDetailResponse = {
+  agent: string;
+  trace_id: string;
+  latency_ms: number | null;
+  num_spans: number;
+  nodes: TraceGraphNode[];
+  edges: TraceGraphEdge[];
+  truncated: boolean;
+};
+
+/**
+ * Challenge 1 — Platform / activity log entries synthesized server-side from
+ * existing observability + registry data. We never call Nasiko logging APIs
+ * directly; each row is derived from a session lifecycle event or a registry
+ * snapshot.
+ */
+export type LogLevel = "INFO" | "WARNING" | "ERROR";
+
+export type SyntheticLogRow = {
+  id: string;
+  ts: string; // ISO-8601
+  level: LogLevel;
+  service: string; // e.g. "agent:a2a-translator", "platform", "registry"
+  message: string;
+  agent_id?: string | null;
+  session_id?: string | null;
+  latency_ms?: number | null;
+  detail?: Record<string, unknown> | null;
+};
+
+export type LogsResponse = {
+  window: string;
+  generated_at: string; // ISO-8601
+  total: number;
+  source_counts: {
+    sessions: number;
+    registry: number;
+  };
+  logs: SyntheticLogRow[];
+};

--- a/web/metrics-dashboard/lib/uptime.ts
+++ b/web/metrics-dashboard/lib/uptime.ts
@@ -1,0 +1,127 @@
+/**
+ * B6: Agent uptime via Kong health probes (in-memory buffer per dev server process).
+ *
+ * Formula (ADR 0002): successful checks / expected checks over 24h at poll interval.
+ * Until the buffer fills, we use recorded checks as the denominator so early
+ * dashboard loads show sensible values (documented in `source.uptime`).
+ */
+
+import { getNasikoApiUrl } from "@/lib/nasiko";
+
+/** 5 minutes — matches plan / ADR poll-interval assumption. */
+export const HEALTH_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+
+type HealthSample = { at: number; ok: boolean };
+
+const buffers = new Map<string, HealthSample[]>();
+
+export type UptimeMeta = {
+  successful_checks: number;
+  recorded_checks: number;
+  expected_checks_24h: number;
+  poll_interval_minutes: number;
+  current_health: boolean;
+};
+
+/** Kong routes Docker agents at `/agents/agent-{agentId}` (strip_path). */
+export function kongAgentPathCandidates(agentId: string): string[] {
+  const dockerName = `agent-${agentId}`;
+  return [
+    `/agents/${dockerName}/health`,
+    `/agents/${agentId}/health`,
+    `/agents/${dockerName}/`,
+    `/agents/${agentId}/`,
+  ];
+}
+
+async function probeUrl(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      cache: "no-store",
+      signal: AbortSignal.timeout(8000),
+    });
+    if (response.status >= 200 && response.status < 500) {
+      return true;
+    }
+    if (response.status === 405) {
+      return true;
+    }
+  } catch {
+    /* try next */
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: "{}",
+      cache: "no-store",
+      signal: AbortSignal.timeout(8000),
+    });
+    return response.status >= 200 && response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+export async function probeAgentHealth(agentId: string): Promise<boolean> {
+  const base = getNasikoApiUrl();
+  for (const path of kongAgentPathCandidates(agentId)) {
+    const ok = await probeUrl(`${base}${path}`);
+    if (ok) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function pruneBuffer(samples: HealthSample[], now: number): HealthSample[] {
+  const cutoff = now - WINDOW_MS;
+  return samples.filter((s) => s.at >= cutoff);
+}
+
+export async function recordAgentHealth(
+  agentId: string,
+  now = Date.now(),
+): Promise<{ uptimePct: number | null; meta: UptimeMeta }> {
+  const existing = buffers.get(agentId) ?? [];
+  const pruned = pruneBuffer(existing, now);
+  const last = pruned[pruned.length - 1];
+
+  if (!last || now - last.at >= HEALTH_POLL_INTERVAL_MS) {
+    const ok = await probeAgentHealth(agentId);
+    pruned.push({ at: now, ok });
+  }
+
+  buffers.set(agentId, pruned);
+
+  const expected = Math.ceil(WINDOW_MS / HEALTH_POLL_INTERVAL_MS);
+  const successful = pruned.filter((s) => s.ok).length;
+  const recorded = pruned.length;
+  const currentHealth = pruned[pruned.length - 1]?.ok ?? false;
+
+  let uptimePct: number | null = null;
+  if (recorded > 0) {
+    const denominator = recorded < expected ? recorded : expected;
+    uptimePct = Math.round((1000 * successful) / denominator) / 10;
+  }
+
+  return {
+    uptimePct,
+    meta: {
+      successful_checks: successful,
+      recorded_checks: recorded,
+      expected_checks_24h: expected,
+      poll_interval_minutes: HEALTH_POLL_INTERVAL_MS / 60_000,
+      current_health: currentHealth,
+    },
+  };
+}
+
+/** Test helper — reset in-memory buffer. */
+export function resetUptimeBuffers(): void {
+  buffers.clear();
+}

--- a/web/metrics-dashboard/next.config.ts
+++ b/web/metrics-dashboard/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // When served behind Kong at /app/metrics/, set basePath: "/app/metrics" and deploy with strip_path.
+  output: "standalone",
+};
+
+export default nextConfig;

--- a/web/metrics-dashboard/package-lock.json
+++ b/web/metrics-dashboard/package-lock.json
@@ -1,0 +1,7449 @@
+{
+  "name": "nasiko-metrics-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nasiko-metrics-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "@xyflow/react": "^12.10.2",
+        "next": "^15.5.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "recharts": "^2.15.4"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.0.0",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "eslint": "^9.0.0",
+        "eslint-config-next": "^15.5.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.18.tgz",
+      "integrity": "sha512-w4MYq8M26a8PNrfto0JosLf5/3ssln1rsyP96g2DkC8uFVymStM5DLSz5ElxxrPRg2XnTMnFo3kREFlhYvxhWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
+      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.18.tgz",
+      "integrity": "sha512-HuoJU6uUPD00eyiud78IBnT4HLhztFj2V+ild2Uon5ZUrYZKe0Olu2QRD99e9IgL4/H1eg5Onka3BsfRW2U0Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "15.5.18",
+        "@rushstack/eslint-patch": "^1.10.3",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.18",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/web/metrics-dashboard/package.json
+++ b/web/metrics-dashboard/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "nasiko-metrics-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3003",
+    "build": "next build",
+    "start": "next start --port 3003",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "smoke": "bash scripts/smoke-api.sh"
+  },
+  "dependencies": {
+    "@xyflow/react": "^12.10.2",
+    "next": "^15.5.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "recharts": "^2.15.4"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.0.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "^15.5.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/web/metrics-dashboard/scripts/smoke-api.sh
+++ b/web/metrics-dashboard/scripts/smoke-api.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# B7 smoke test — requires metrics dev server + Nasiko stack + Bearer token.
+set -euo pipefail
+
+BASE="${METRICS_BASE_URL:-http://localhost:3003}"
+TOKEN="${NASIKO_BEARER_TOKEN:-}"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "Set NASIKO_BEARER_TOKEN (JWT from nasiko-credentials-*.json access_token)" >&2
+  exit 1
+fi
+
+AUTH=(-H "Authorization: Bearer ${TOKEN}")
+
+echo "== GET /api/health =="
+curl -sf "${BASE}/api/health" | head -c 200
+echo -e "\n"
+
+echo "== GET /api/agents =="
+AGENTS_JSON=$(curl -sf "${BASE}/api/agents" "${AUTH[@]}")
+echo "$AGENTS_JSON" | head -c 300
+echo -e "\n"
+
+AGENT_ID=$(echo "$AGENTS_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['agents'][0]['agentId'] if d.get('agents') else '')" 2>/dev/null || true)
+if [[ -z "$AGENT_ID" ]]; then
+  echo "No agents in list — deploy an agent first" >&2
+  exit 1
+fi
+
+echo "== GET /api/metrics?agent=${AGENT_ID}&window=24h =="
+METRICS_JSON=$(curl -sf "${BASE}/api/metrics?agent=${AGENT_ID}&window=24h" "${AUTH[@]}")
+echo "$METRICS_JSON" | python3 -m json.tool 2>/dev/null | head -40
+
+python3 - <<'PY' "$METRICS_JSON"
+import json, sys
+m = json.loads(sys.argv[1])
+required = ["agent", "window", "avg_latency_ms", "success", "error", "uptime_pct", "series_24h"]
+for k in required:
+    assert k in m, f"missing key: {k}"
+assert len(m["series_24h"]) == 24, "series_24h must have 24 buckets"
+assert m["uptime_pct"] is not None, "uptime_pct should be set after B6"
+print("OK — metrics contract validated")
+PY
+
+echo "Smoke test passed."

--- a/web/metrics-dashboard/tsconfig.json
+++ b/web/metrics-dashboard/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/web/metrics-dashboard/vitest.config.ts
+++ b/web/metrics-dashboard/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
challenge 2 Video url - https://youtu.be/K-1dlkMleGU

challenge 1 video url - https://youtu.be/TSwYUz5CRWM

TEAM - first order

## CHALLENGE 2

Implements **Titan Builder Challenge 2**: a new **Agent Performance Metrics** experience in `web/metrics-dashboard/` so logged-in users can monitor **per-agent** latency, reliability, availability, cost, and request-level traces — without leaving the Nasiko web UI.
- **Dev URL:** http://localhost:3003  
- **Production target:** `/app/metrics/` behind Kong (same host as main app for shared JWT)  
- **Stack:** Next.js 15 App Router, React 19, TypeScript, Recharts, Vitest  
- **No new Nasiko backend routes** — all data comes from existing registry + observability APIs, with rollup and uptime logic in Next.js Route Handlers.
---
## Challenge requirements → implementation
| Requirement | Implementation |
|---------------|----------------|
| New metrics page in web UI | `app/page.tsx` → `MetricsDashboard` |
| Per deployed agent | Agent dropdown from registry; optional **All agents** fleet view |
| Average response time | **Typical response time** — session p50 latency + inline **24h sparkline** in KPI card |
| Success / error counts | Rolled up from observability sessions (`lib/rollup.ts`) |
| Uptime % | Kong health polls every **5 min**, 24h rolling buffer (`lib/uptime.ts`) |
| Chart for last 24h | **Traffic chart** — stacked hourly bars (success vs failed); sparkline for latency trend |
| PR to main | This PR |
---
## Features
### Single-agent view
- **KPI cards:** typical response time, successful requests, failed requests, availability %, estimated AI cost (with prompt vs completion split when available)
- **Tier-B KPIs (conditional):** user feedback (mean score + label distribution bar), avg steps per request when `num_traces` is present
- **Traffic chart:** hourly stacked bars (green = success, red = failed); tooltip shows totals, split, and typical latency for that hour
- **Time range bar:** presets **1h / 24h / 7d** (max 7 days); `startTime` / `endTime` passed to APIs and session filtering
- **Auto-refresh:** optional 60s refresh + “Updated Xs ago” indicator
- **Request traces workspace:** paginated session table (10/page) + **n8n-style horizontal workflow graph** on the right
  - Node types: user prompt → LLM → agent → tool
  - Green/red borders for success vs failure
  - Infrastructure spans (JSON-RPC, callbacks, middleware) filtered out (`lib/trace-pipeline.ts`)
  - Fullscreen canvas mode
  - Status chips: All / Success / Failed
- **Auth states:** sign-in screen (JWT paste on `:3003`), loading, error, empty/no-data
### Fleet view (“All agents”)
- Parallel metrics fetch per agent (`lib/fleet-rollup.ts`)
- Aggregated fleet KPIs + **Agents overview table** with per-agent comparison
- **View details** drills into single-agent view
### Related route (same app)
- Challenge 1 platform logs at `/logs` (separate concern; can be a follow-up PR if splitting submissions)

<img width="2806" height="1476" alt="image" src="https://github.com/user-attachments/assets/89b1d83f-e9f6-4f17-aab5-55cf378b43de" />
<img width="1440" height="900" alt="Screenshot 2026-05-17 at 03 18 12" src="https://github.com/user-attachments/assets/c1e63ff1-b265-4fac-86f9-a92410485801" />
<img width="1440" height="900" alt="Screenshot 2026-05-17 at 03 19 34" src="https://github.com/user-attachments/assets/7352faff-9917-49d4-9a58-83317ae2cde4" />
<img width="1440" height="900" alt="Screenshot 2026-05-17 at 03 19 51" src="https://github.com/user-attachments/assets/850617c1-b3d0-4994-87c3-0f1aff761f3f" />

## CHALLENGE 1

Adds a **Platform Logs** page to the Nasiko web UI so operators can review recent platform activity in one place, with filtering by log level (INFO / WARNING / ERROR).

Implements **Titan Builder Challenge 1** in `web/metrics-dashboard/` at route `/logs`.

## What’s included

- **New page:** `app/logs/page.tsx` → `LogsView` with table columns: Time, Level, Service, Message, Session, Latency
- **Level filters:** chip filters for INFO / WARNING / ERROR (multi-select) plus text search
- **Row detail:** expandable JSON for structured session metadata
- **API:** `GET /api/logs` — server-side synthesis from existing observability sessions (no new Nasiko backend routes)

## Design decisions

- **No new log pipeline** — log rows are derived from `GET /api/v1/observability/session/list` and agent registry data already exposed by Nasiko:
  - INFO at session start (“Request received”)
  - INFO / WARNING / ERROR at session end based on outcome and latency (e.g. slow > 5s → WARNING)
- Keeps the challenge scoped to **UI + BFF rollup** on top of current APIs.

## Nasiko API endpoints used

| Endpoint | Purpose |
|----------|---------|
| `GET /api/v1/registry/user/agents` | Service / agent labels |
| `GET /api/v1/observability/session/list?start_time=…` | Session stream for log synthesis |

Auth: `Authorization: Bearer <JWT>` forwarded from the Next.js route handler.

## How to test

1. Start local Nasiko stack (Kong `:9100`, agents, Phoenix).
2. From `web/metrics-dashboard/`:
   ```bash
   npm install && npm run dev


<img width="1440" height="900" alt="Screenshot 2026-05-17 at 03 21 21" src="https://github.com/user-attachments/assets/59ae7434-db32-4451-b440-044fa14ce696" />
<img width="1440" height="900" alt="Screenshot 2026-05-17 at 03 21 48" src="https://github.com/user-attachments/assets/77b1ff9c-5670-49ae-b4c1-4c6783c3989c" />
<img width="1440" height="900" alt="Screenshot 2026-05-17 at 03 22 05" src="https://github.com/user-attachments/assets/cf94e12e-163a-4a66-bd8b-74be0883f642" />


