### PR TITLE
feat(minimax): upgrade to MiniMax-M3 as default model

### DIFF
--- a/.nasiko-local.env.example
+++ b/.nasiko-local.env.example
@@ -57,7 +57,7 @@ MINIMAX_API_KEY=your-minimax-api-key
 # Supported values: "openai" (default), "openrouter", "minimax"
 # ROUTER_LLM_PROVIDER=openai
 # ROUTER_LLM_MODEL=gpt-4o-mini
-# For MiniMax: ROUTER_LLM_PROVIDER=minimax, ROUTER_LLM_MODEL=MiniMax-M2.7
+# For MiniMax: ROUTER_LLM_PROVIDER=minimax, ROUTER_LLM_MODEL=MiniMax-M3
 
 # Kong Database
 KONG_DB_NAME=kong

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Nasiko supports multiple LLM providers for both the routing engine and agent exe
 | Provider | API Key Env Var | Base URL | Models |
 |----------|----------------|----------|--------|
 | OpenAI (default) | `OPENAI_API_KEY` | Default OpenAI endpoint | gpt-4o, gpt-4o-mini |
-| [MiniMax](https://platform.minimax.io) | `MINIMAX_API_KEY` | `https://api.minimax.io/v1` (global) / `https://api.minimaxi.com/v1` (China) | MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed |
+| [MiniMax](https://platform.minimax.io) | `MINIMAX_API_KEY` | `https://api.minimax.io/v1` (global) / `https://api.minimaxi.com/v1` (China) | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | OpenRouter | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1` | Various models |
 
 To switch the router's LLM provider, set `ROUTER_LLM_PROVIDER` and `ROUTER_LLM_MODEL` in your environment configuration. See [Environment Configuration](#-environment-configuration).

--- a/agent-gateway/router/src/core/routing_engine.py
+++ b/agent-gateway/router/src/core/routing_engine.py
@@ -44,7 +44,7 @@ class RoutingEngine:
 
         if provider == "minimax":
             return ChatOpenAI(
-                model=model or "MiniMax-M2.7",
+                model=model or "MiniMax-M3",
                 temperature=1.0,
                 api_key=settings.MINIMAX_API_KEY,
                 base_url=settings.MINIMAX_BASE_URL,

--- a/agent-gateway/router/tests/test_minimax_provider.py
+++ b/agent-gateway/router/tests/test_minimax_provider.py
@@ -30,7 +30,7 @@ class TestRouterConfigMiniMax:
             "MINIMAX_API_KEY": "test-minimax-key",
             "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
             "ROUTER_LLM_PROVIDER": "minimax",
-            "ROUTER_LLM_MODEL": "MiniMax-M2.7",
+            "ROUTER_LLM_MODEL": "MiniMax-M3",
         }
         from router.src.config.settings import RouterConfig
 
@@ -68,13 +68,13 @@ class TestRoutingEngineLLMCreation:
         """When provider is 'minimax', correct model/temperature/base_url are used."""
         # Test the provider selection logic directly
         provider = "minimax"
-        model = "MiniMax-M2.7"
+        model = "MiniMax-M3"
         api_key = "test-key"
         base_url = "https://api.minimax.io/v1"
 
         if provider == "minimax":
             config = {
-                "model": model or "MiniMax-M2.7",
+                "model": model or "MiniMax-M3",
                 "temperature": 1.0,
                 "api_key": api_key,
                 "base_url": base_url,
@@ -86,7 +86,7 @@ class TestRoutingEngineLLMCreation:
                 "api_key": api_key,
             }
 
-        assert config["model"] == "MiniMax-M2.7"
+        assert config["model"] == "MiniMax-M3"
         assert config["temperature"] == 1.0
         assert config["api_key"] == "test-key"
         assert config["base_url"] == "https://api.minimax.io/v1"
@@ -99,7 +99,7 @@ class TestRoutingEngineLLMCreation:
 
         if provider == "minimax":
             config = {
-                "model": model or "MiniMax-M2.7",
+                "model": model or "MiniMax-M3",
                 "temperature": 1.0,
                 "api_key": api_key,
                 "base_url": "https://api.minimax.io/v1",
@@ -135,17 +135,17 @@ class TestRoutingEngineLLMCreation:
         assert temperature > 0
 
     def test_minimax_default_model_fallback(self):
-        """When model is empty string, MiniMax should fall back to MiniMax-M2.7."""
+        """When model is empty string, MiniMax should fall back to MiniMax-M3."""
         model = ""
-        result = model or "MiniMax-M2.7"
-        assert result == "MiniMax-M2.7"
+        result = model or "MiniMax-M3"
+        assert result == "MiniMax-M3"
 
     def test_openrouter_provider_selects_correct_config(self):
         """When provider is 'openrouter', correct base_url is used."""
         provider = "openrouter"
 
         if provider == "minimax":
-            base_url = "https://api.minimax.io/v1"  # MiniMax-M2.7 default
+            base_url = "https://api.minimax.io/v1"  # MiniMax-M3 default
         elif provider == "openrouter":
             base_url = "https://openrouter.ai/api/v1"
         else:
@@ -158,40 +158,37 @@ class TestMiniMaxModels:
     """Test MiniMax model configuration."""
 
     def test_default_minimax_model(self):
-        """Default MiniMax model should be MiniMax-M2.7."""
-        model = "MiniMax-M2.7"
-        assert model == "MiniMax-M2.7"
+        """Default MiniMax model should be MiniMax-M3."""
+        model = "MiniMax-M3"
+        assert model == "MiniMax-M3"
 
     def test_highspeed_model_available(self):
         """MiniMax-M2.7-highspeed should be a valid model option."""
         valid_models = [
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
         ]
         assert "MiniMax-M2.7-highspeed" in valid_models
 
-    def test_m27_models_before_m25(self):
-        """M2.7 models should appear before M2.5 models in the list."""
+    def test_m3_model_before_m27(self):
+        """M3 should appear before M2.7 models in the list (newest first)."""
         valid_models = [
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
         ]
-        assert valid_models.index("MiniMax-M2.7") < valid_models.index("MiniMax-M2.5")
+        assert valid_models.index("MiniMax-M3") < valid_models.index("MiniMax-M2.7")
 
-    def test_legacy_models_still_available(self):
-        """Previous M2.5 models should still be available."""
+    def test_legacy_m27_models_still_available(self):
+        """Previous M2.7 models should still be available alongside M3."""
         valid_models = [
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
         ]
-        assert "MiniMax-M2.5" in valid_models
-        assert "MiniMax-M2.5-highspeed" in valid_models
+        assert "MiniMax-M2.7" in valid_models
+        assert "MiniMax-M2.7-highspeed" in valid_models
 
 
 class TestFrameworkDetection:

--- a/agents/a2a-compliance-checker/src/__main__.py
+++ b/agents/a2a-compliance-checker/src/__main__.py
@@ -38,7 +38,7 @@ def main(host: str, port: int, mongo_url: str, db_name: str):
 
     if os.getenv("MINIMAX_API_KEY") and not os.getenv("OPENAI_API_KEY"):
         base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
-        model = os.getenv("MINIMAX_MODEL", "MiniMax-M2.7")
+        model = os.getenv("MINIMAX_MODEL", "MiniMax-M3")
 
     if not api_key:
         raise ValueError(

--- a/agents/a2a-compliance-checker/src/agent.py
+++ b/agents/a2a-compliance-checker/src/agent.py
@@ -20,7 +20,7 @@ def _create_llm() -> ChatOpenAI:
     """Create LLM instance, supporting OpenAI and MiniMax providers."""
     if os.getenv("MINIMAX_API_KEY") and not os.getenv("OPENAI_API_KEY"):
         return ChatOpenAI(
-            model=os.getenv("MINIMAX_MODEL", "MiniMax-M2.7"),
+            model=os.getenv("MINIMAX_MODEL", "MiniMax-M3"),
             temperature=1.0,
             api_key=os.getenv("MINIMAX_API_KEY"),
             base_url=os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1"),

--- a/agents/a2a-github-agent/src/__main__.py
+++ b/agents/a2a-github-agent/src/__main__.py
@@ -38,7 +38,7 @@ def main(host: str, port: int):
 
     if os.getenv("MINIMAX_API_KEY") and not os.getenv("OPENAI_API_KEY"):
         base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
-        model = os.getenv("MINIMAX_MODEL", "MiniMax-M2.7")
+        model = os.getenv("MINIMAX_MODEL", "MiniMax-M3")
 
     if not api_key:
         raise ValueError(

--- a/agents/a2a-translator/src/__main__.py
+++ b/agents/a2a-translator/src/__main__.py
@@ -38,7 +38,7 @@ def main(host: str, port: int):
     elif os.getenv("MINIMAX_API_KEY"):
         api_key = os.getenv("MINIMAX_API_KEY")
         base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
-        model = os.getenv("MINIMAX_MODEL", "MiniMax-M2.7")
+        model = os.getenv("MINIMAX_MODEL", "MiniMax-M3")
     else:
         api_key = os.getenv("OPENAI_API_KEY")
 

--- a/app/utils/agentcard_generator/agent.py
+++ b/app/utils/agentcard_generator/agent.py
@@ -60,7 +60,7 @@ class AgentCardGeneratorAgent:
         ):
             base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
             if model == "gpt-4o":
-                model = os.getenv("MINIMAX_MODEL", "MiniMax-M2.7")
+                model = os.getenv("MINIMAX_MODEL", "MiniMax-M3")
 
         logger.info(f"Initializing AgentCardGeneratorAgent with model: {model}")
         self.client = OpenAI(api_key=self.api_key, base_url=base_url)


### PR DESCRIPTION
## Summary

Upgrades the bundled MiniMax provider integration to use **MiniMax-M3** as the default model. M3 is MiniMax's latest flagship reasoning model and replaces M2.7 as the recommended option.

### Changes

- Default fallback for `MINIMAX_MODEL` is now `MiniMax-M3` in:
  - `agent-gateway/router/src/core/routing_engine.py` (router LLM)
  - `app/utils/agentcard_generator/agent.py` (agentcard generator)
  - `agents/a2a-translator/src/__main__.py`
  - `agents/a2a-compliance-checker/src/{__main__.py,agent.py}`
  - `agents/a2a-github-agent/src/__main__.py`
- README and `.nasiko-local.env.example` updated to advertise M3 as the recommended model.
- `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available for users who want to pin to the previous generation.
- Removed `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` from the documented model list (older generation, no longer recommended).
- Tests in `agent-gateway/router/tests/test_minimax_provider.py` updated to assert M3 is the default and is listed first.

### Why

M3 has stronger reasoning, longer context, and the same OpenAI-compatible interface — no code path changes required, just the default model ID. Users who relied on M2.7 can still set `MINIMAX_MODEL=MiniMax-M2.7` (or the highspeed variant) explicitly.

### Test plan

- [x] `pytest agent-gateway/router/tests/test_minimax_provider.py` — all 15 tests pass locally
- [x] No changes to API URL, temperature, or other provider plumbing
- [x] Backwards compatible: `MINIMAX_MODEL` env var still overrides the default