### PR TITLE
docs: add a live web search MCP setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,26 @@ pull from the artifact registry.
 
 Run `nasiko --help` for the full, workflow-ordered command list.
 
+### Add live web search through MCP
+
+Parallel Search MCP is a free, no-account, no-API-key remote MCP endpoint for live web search and
+URL fetching. Register it with Nasiko's existing gateway:
+
+```sh
+nasiko mcp connector register parallel-search https://search.parallel.ai/mcp \
+  --display-name "Parallel Search" \
+  --description "Live web search and URL fetching"
+```
+
+The command prints a connector ID. Enable that connector for an agent:
+
+```sh
+nasiko mcp agent-tools enable <agent> <connector-id>
+```
+
+The agent can then use the connector's `web_search` and `web_fetch` tools through Nasiko's
+existing permission controls.
+
 ## Environment Variables
 
 Everything is env-driven through a single `Config` struct (`config/src/lib.rs`); required keys fail


### PR DESCRIPTION
Nasiko already supports remote MCP connectors, but the README currently stops at listing the top-level `nasiko mcp` command. This adds a concrete setup example for giving an agent live web search and URL fetching through the existing gateway.

## What changed

- show how to register the no-auth Parallel Search MCP endpoint
- show how to enable the returned connector for one agent
- name the `web_search` and `web_fetch` tools the connector exposes

## Validation

- ran `git diff --check`
- verified the documented commands, flags, and defaults against `cli/src/lib.rs`
- confirmed the patch changes only `README.md`

This is documentation-only; I did not run a live Nasiko deployment for the example.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.