### PR TITLE
fix: resolve compile errors blocking docker compose up -d and restore  dropped deploy optimization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,7 +113,13 @@ OPENAI_MODEL=gpt-4o-mini
 # Examples: gmail, slack, googlecalendar, github, notion, jira, linear, asana,
 # trello, discord, dropbox, salesforce, hubspot, zendesk, intercom, stripe,
 # airtable, clickup, monday, gitlab, pagerduty, sentry, confluence, bitbucket,
-# googledrive, googlesheets. No-op without COMPOSIO_API_KEY.
+# googledrive, googlesheets.
+#
+# NO-OP without COMPOSIO_API_KEY set above — ships active by default, so a
+# fresh `docker compose up -d` logs "SEED_TOOLKITS is set but
+# COMPOSIO_API_KEY is not — cannot register Composio toolkits without an API
+# key" on every boot. That's expected and harmless if you don't need Composio
+# toolkits; set COMPOSIO_API_KEY (or clear this var) to silence it.
 SEED_TOOLKITS=gmail,slack,notion,github,googlecalendar
 
 # Public URL of the MCP gateway, injected into every deployed agent as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,6 +3685,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "futures",
+ "mockito",
  "nasiko-auth",
  "nasiko-types",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ docs/           Design docs (architecture, protocol, conventions)
 | Agent upload -> `500 agents_owner_id_fkey` | Log out and back in, or `docker compose down -v && docker compose up -d` then log in fresh |
 | Server can't reach Postgres | `docker compose up -d` and wait for `healthy` |
 | Agent `Name or service not known` (Linux Docker) | Recreate with `--add-host host.docker.internal:host-gateway` |
+| `SEED_TOOLKITS is set but COMPOSIO_API_KEY is not` at startup | Expected and harmless — `SEED_TOOLKITS` ships active by default in `.env.example`. Set `COMPOSIO_API_KEY` in `.env` to actually register Composio toolkits, or comment out `SEED_TOOLKITS` to silence the warning |
 
 ### Windows
 

--- a/cli/src/commands/deploy.rs
+++ b/cli/src/commands/deploy.rs
@@ -7,7 +7,9 @@ use anyhow::{Context, Result};
 use crate::api::{Client, ContainerStatus, DeploySpec};
 use crate::oci;
 use crate::util::parse_image_name_and_tag;
-use crate::version_prompt::{VersionContext, VersionFlags, resolve_deploy_version};
+use crate::version_prompt::{
+    VersionContext, VersionFlags, resolve_deploy_version, resolve_image_deploy_version,
+};
 
 const AGENT_FILE: &str = ".nasiko/agent.json";
 
@@ -63,6 +65,28 @@ fn used_version_context<'a>(
         None => Vec::new(),
     };
     Ok((current_deployed_version, used_versions))
+}
+
+/// Whether `version` is already recorded with `status = "pushed"` for this
+/// agent — an image `nasiko push` made available in the registry but never
+/// deployed. When true, the artifact is already sitting in the registry
+/// under this exact tag, so deploy must promote it as-is instead of
+/// re-uploading: an OCI tag isn't content-addressed, so pushing again would
+/// silently repoint it if the local image has changed since the push.
+fn already_pushed(
+    client: &Client,
+    existing: Option<&(String, serde_json::Value)>,
+    version: &str,
+) -> Result<bool> {
+    let Some((id, _)) = existing else {
+        return Ok(false);
+    };
+    let status = client
+        .version_history(id)?
+        .into_iter()
+        .find(|v| v.version == version)
+        .map(|v| v.status);
+    Ok(status.as_deref() == Some("pushed"))
 }
 
 /// Finds the existing agent for a directory deploy: first checks the local
@@ -162,18 +186,25 @@ fn deploy_from_directory(
     };
     let decision = resolve_deploy_version(context, flags)?;
     let version = decision.version;
-    let image_tag = format!("{agent_name}:{version}");
-
-    // Build for linux/amd64 (the cluster's arch), not the host arch — an
-    // Apple Silicon build here would CrashLoop with "exec format error".
-    super::build::build(dir, Some(&image_tag), Some("linux/amd64"))?;
-
-    // Push image to OCI
     let repo = format!("nasiko/{agent_name}");
-    println!("Pushing {image_tag} → {repo}:{version}...");
-    oci::push_image(&image_tag, &repo, &version)?;
-
     let image_ref = format!("{repo}:{version}");
+
+    if already_pushed(client, existing.as_ref(), &version)? {
+        println!(
+            "  Version {version} was already pushed — deploying the existing registry image \
+             without rebuilding."
+        );
+    } else {
+        let image_tag = format!("{agent_name}:{version}");
+
+        // Build for linux/amd64 (the cluster's arch), not the host arch — an
+        // Apple Silicon build here would CrashLoop with "exec format error".
+        super::build::build(dir, Some(&image_tag), Some("linux/amd64"))?;
+
+        // Push image to OCI
+        println!("Pushing {image_tag} → {repo}:{version}...");
+        oci::push_image(&image_tag, &repo, &version)?;
+    }
 
     let agent_id = match existing {
         Some((id, current)) => {
@@ -181,11 +212,7 @@ fn deploy_from_directory(
                 .get("version")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            if decision.overwrite {
-                println!("  Overwriting: {version} (was: {current_version})");
-            } else {
-                println!("  Updating: {current_version} → {version}");
-            }
+            println!("  Updating: {current_version} → {version}");
             save_agent_id(&agent_file, &id, &agent_name)?;
 
             // Deploy the container BEFORE activating the new version in the
@@ -212,7 +239,6 @@ fn deploy_from_directory(
                 "description": card.get("description"),
                 "skills": card.get("skills"),
                 "capabilities": card.get("capabilities"),
-                "allow_overwrite": decision.overwrite,
             });
             let _: serde_json::Value = client.put_json(&format!("/agents/{id}"), &update)?;
             if let Err(e) = crate::util::sync_card_version(&card_path, &card, &version) {
@@ -290,34 +316,35 @@ fn deploy_from_image(
     });
     let (current_deployed_version, used_versions) =
         used_version_context(client, existing.as_ref())?;
-    // Only trust the tag if the user actually wrote one (`image:tag`) — a
-    // bare `image` implicitly means Docker's "latest", not a real choice.
-    let card_version =
-        crate::util::image_has_explicit_tag(image).then_some(image_tag_version.as_str());
-    let context = VersionContext {
-        card_version,
+    let decision = resolve_image_deploy_version(
+        image,
+        &image_tag_version,
+        flags,
         current_deployed_version,
-        used_versions: &used_versions,
-    };
-    let decision = resolve_deploy_version(context, flags)?;
+        &used_versions,
+        "deploy",
+    )?;
     let version = decision.version;
 
     let image_ref = format!("{repo}:{version}");
 
-    // Tag locally so Docker can find it by the canonical ref without a registry pull.
-    let _ = std::process::Command::new("docker")
-        .args(["tag", image, &image_ref])
-        .status();
+    if already_pushed(client, existing.as_ref(), &version)? {
+        println!(
+            "  Version {version} was already pushed — deploying the existing registry image \
+             without re-pushing."
+        );
+    } else {
+        // Tag locally so Docker can find it by the canonical ref without a registry pull.
+        let _ = std::process::Command::new("docker")
+            .args(["tag", image, &image_ref])
+            .status();
 
-    println!("Pushing {image} → {image_ref}...");
-    oci::push_image(image, &repo, &version)?;
+        println!("Pushing {image} → {image_ref}...");
+        oci::push_image(image, &repo, &version)?;
+    }
 
     if let Some((id, _)) = existing {
-        if decision.overwrite {
-            println!("  Overwriting agent: {agent_name} @ {version}");
-        } else {
-            println!("  Updating agent: {agent_name}");
-        }
+        println!("  Updating agent: {agent_name}");
 
         // Deploy the container BEFORE activating the new version in the
         // catalog — see the matching comment in `deploy_from_directory`.
@@ -336,7 +363,6 @@ fn deploy_from_image(
         let update = serde_json::json!({
             "version": version,
             "image": image_ref,
-            "allow_overwrite": decision.overwrite,
         });
         let _: serde_json::Value = client.put_json(&format!("/agents/{id}"), &update)?;
         println!("\n✓ Deployed {agent_name}:{version}");

--- a/cli/src/commands/push.rs
+++ b/cli/src/commands/push.rs
@@ -161,7 +161,12 @@ fn reject_if_already_pushed(
     let Some((id, _)) = existing else {
         return Ok(());
     };
-    let Some(status) = client.version_status(id, version)? else {
+    let history = client.version_history(id)?;
+    let Some(status) = history
+        .into_iter()
+        .find(|v| v.version == version)
+        .map(|v| v.status)
+    else {
         return Ok(());
     };
     if status == "pushed" {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -108,10 +108,6 @@ pub enum AgentOpsCommands {
         /// Non-interactive: auto-accept the suggested version instead of prompting
         #[arg(long, short = 'y')]
         yes: bool,
-        /// Explicit consent to replace an already-used version's content in place
-        /// (only takes effect together with --version; interactive runs are asked instead)
-        #[arg(long)]
-        overwrite: bool,
     },
     /// Push image to cluster OCI registry (without deploying)
     Push {
@@ -126,10 +122,6 @@ pub enum AgentOpsCommands {
         /// Non-interactive: auto-accept the suggested version instead of prompting
         #[arg(long, short = 'y')]
         yes: bool,
-        /// Explicit consent to replace an already-used version's content in place
-        /// (only takes effect together with --version; interactive runs are asked instead)
-        #[arg(long)]
-        overwrite: bool,
     },
     /// Upload source directory or .zip and let the server build + deploy (no local Docker needed)
     #[command(
@@ -905,7 +897,6 @@ pub fn dispatch_agent_dev(cmd: AgentDevCommands) -> Result<()> {
             platform.as_deref(),
             version_prompt::VersionFlags {
                 version: version.as_deref(),
-                overwrite: false,
                 yes,
             },
         ),
@@ -938,7 +929,6 @@ pub fn dispatch_agent_ops(cmd: AgentOpsCommands) -> Result<()> {
             writable_path,
             version,
             yes,
-            overwrite,
         } => commands::deploy::deploy_with_version_flags(
             &image,
             name.as_deref(),
@@ -947,7 +937,6 @@ pub fn dispatch_agent_ops(cmd: AgentOpsCommands) -> Result<()> {
             &env,
             version_prompt::VersionFlags {
                 version: version.as_deref(),
-                overwrite,
                 yes,
             },
             writable,
@@ -958,13 +947,11 @@ pub fn dispatch_agent_ops(cmd: AgentOpsCommands) -> Result<()> {
             name,
             version,
             yes,
-            overwrite,
         } => commands::push::push_with_version_flags(
             &image,
             name.as_deref(),
             version_prompt::VersionFlags {
                 version: version.as_deref(),
-                overwrite,
                 yes,
             },
         ),

--- a/mcp-gateway/src/router.rs
+++ b/mcp-gateway/src/router.rs
@@ -60,6 +60,7 @@ mod tests {
             url: url.into(),
             headers: HashMap::new(),
             transport: "streamable_http".into(),
+            trusted: false,
         }
     }
 

--- a/react-agent/Cargo.toml
+++ b/react-agent/Cargo.toml
@@ -33,6 +33,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 tracing-subscriber = { workspace = true }
+mockito = { workspace = true }
 
 [[example]]
 name = "test_tools"

--- a/server/.env.example
+++ b/server/.env.example
@@ -135,6 +135,9 @@ RUST_LOG=info
 #   gitlab pagerduty sentry confluence bitbucket googlecalendar googledrive
 #   googlesheets
 #
+# NO-OP without COMPOSIO_API_KEY set above — uncommenting this alone logs a
+# "cannot register Composio toolkits without an API key" warning at boot and
+# does nothing further.
 # SEED_TOOLKITS=gmail,calendar,slack,notion,github,googlecalendar
 
 # Public URL of the MCP gateway, injected into every deployed agent's env as

--- a/server/src/agents/update.rs
+++ b/server/src/agents/update.rs
@@ -593,7 +593,6 @@ pub async fn execute_agent_update(
                     version: &new_version,
                     image_tag: &image_tag,
                     changelog: changelog.as_deref(),
-                    allow_overwrite: false,
                 }
             })
             .await;

--- a/server/src/agents/upload.rs
+++ b/server/src/agents/upload.rs
@@ -847,7 +847,6 @@ async fn record_uploaded_version(
         version: &version_tag,
         image_tag,
         changelog: None,
-        allow_overwrite: false,
     })
     .await;
 }


### PR DESCRIPTION
- Remove stale allow_overwrite/overwrite field references left over from
  the version-immutability refactor (server/agents, cli deploy/push)
- Restore already_pushed()/resolve_image_deploy_version() in deploy.rs,
  silently dropped by a bad merge (9bdc080), with tests passing again
- Fix missing mockito dev-dependency in nasiko-react-agent
- Set the trusted field on MCPServerConfig test fixture
- Document the SEED_TOOLKITS/COMPOSIO_API_KEY startup warning
- Verified: cargo build --release -p nasiko-server, cargo test --workspace,
  and a real docker compose up -d --build all pass end-to-end