### PR TITLE
ci: publish nasiko-server to Docker Hub, pull the image by default

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Publish Docker image
+
+# Builds nasiko-server (server/Dockerfile) and pushes it to Docker Hub as
+# skmallick/nasiko-oss-server, multi-arch (amd64 + arm64). Triggered by
+# pushing a version tag (e.g. v0.1.0) — tags the image with that version and
+# moves `latest` to it. Requires repo secrets DOCKERHUB_USERNAME and
+# DOCKERHUB_TOKEN (a Docker Hub access token, not the account password).
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: skmallick/nasiko-oss-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: server/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ docs/           Design docs (architecture, protocol, conventions)
 
 ## Troubleshooting
 
-### Quick fixes - one command
+### Quick fixes: one command
 
 | Problem | One command |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ flowchart LR
 ## Quick Start — Docker only (no Rust needed)
 
 The fastest way to run Nasiko requires **only [Docker](https://docs.docker.com/get-docker/)** (with Compose).
-The server builds itself from source inside Docker.
+The server pulls a pre-built image from Docker Hub — no local Rust or compile step.
 
 ### 1. Clone and configure
 
@@ -241,17 +241,19 @@ Edit `.env` and set at minimum:
 docker compose up -d
 ```
 
-This builds the server image and starts the full stack:
+This pulls the server image and starts the full stack:
 **Postgres · Redis · RustFS (S3) · OTel Collector · Tempo · Loki · nasiko-server**.
 
-- First build takes a few minutes (compiles Rust inside Docker) — subsequent builds are fast.
 - Open **http://localhost:8080** for the dashboard and log in with `ADMIN_USERNAME` / `ADMIN_PASSWORD`
   (default `admin` / `changeme`).
+- To build the server from source instead of pulling (e.g. to test a local change):
+  `docker compose build server && docker compose up -d`.
 
 ```sh
 docker compose logs -f server   # follow server logs
 docker compose down             # stop everything
-docker compose up -d --build    # rebuild after pulling new changes
+docker compose pull server && docker compose up -d   # update to the latest published image
+docker compose up -d --build                          # rebuild from local source instead
 ```
 
 > No Docker? Use the [Developer / Rust setup](#path-b--developer--rust-setup) below.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ flowchart LR
 ## Quick Start — Docker only (no Rust needed)
 
 The fastest way to run Nasiko requires **only [Docker](https://docs.docker.com/get-docker/)** (with Compose).
-The server pulls a pre-built image from Docker Hub — no local Rust or compile step.
+The server builds itself from source inside Docker.
 
 ### 1. Clone and configure
 
@@ -241,19 +241,17 @@ Edit `.env` and set at minimum:
 docker compose up -d
 ```
 
-This pulls the server image and starts the full stack:
+This builds the server image and starts the full stack:
 **Postgres · Redis · RustFS (S3) · OTel Collector · Tempo · Loki · nasiko-server**.
 
+- First build takes a few minutes (compiles Rust inside Docker) — subsequent builds are fast.
 - Open **http://localhost:8080** for the dashboard and log in with `ADMIN_USERNAME` / `ADMIN_PASSWORD`
   (default `admin` / `changeme`).
-- To build the server from source instead of pulling (e.g. to test a local change):
-  `docker compose build server && docker compose up -d`.
 
 ```sh
 docker compose logs -f server   # follow server logs
 docker compose down             # stop everything
-docker compose pull server && docker compose up -d   # update to the latest published image
-docker compose up -d --build                          # rebuild from local source instead
+docker compose up -d --build    # rebuild after pulling new changes
 ```
 
 > No Docker? Use the [Developer / Rust setup](#path-b--developer--rust-setup) below.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,6 @@
 #
 # Copy .env.example to .env and edit before starting:
 #   cp .env.example .env
-#
-# Pulls the published skmallick/nasiko-oss-server image by default — no Rust
-# or local compile needed. Building from source instead (e.g. to test an
-# unreleased change): docker compose build server && docker compose up -d.
 
 services:
   postgres:
@@ -90,7 +86,6 @@ services:
       - nasiko
 
   server:
-    image: skmallick/nasiko-oss-server:latest
     build:
       context: .
       dockerfile: server/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@
 #
 # Copy .env.example to .env and edit before starting:
 #   cp .env.example .env
+#
+# Pulls the published skmallick/nasiko-oss-server image by default — no Rust
+# or local compile needed. Building from source instead (e.g. to test an
+# unreleased change): docker compose build server && docker compose up -d.
 
 services:
   postgres:
@@ -86,6 +90,7 @@ services:
       - nasiko
 
   server:
+    image: skmallick/nasiko-oss-server:latest
     build:
       context: .
       dockerfile: server/Dockerfile


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-publish.yml`: builds `server/Dockerfile` multi-arch (amd64+arm64) and pushes `skmallick/nasiko-oss-server` to Docker Hub on every version tag (`v*`), tagging both the version and `latest`.
- Switches `docker-compose.yml`'s `server` service to `image:` (pulls by default) instead of always building from source — the Quick Start becomes a real `docker compose up -d` with no local Rust/compile step. The `build:` section stays, so `docker compose build server` still works for anyone testing an unreleased change.
- Updates the README's Quick Start wording and the logs/rebuild cheat-sheet to match (pull vs. build-from-source).

A manually-built image is already live at `skmallick/nasiko-oss-server:latest` (and `:20260907`) so the new Quick Start works today; future pushes will be automated by this workflow on release tags.

## Required setup (repo admin)
This workflow needs two repo secrets before it can run:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (a Docker Hub access token, not the account password)

## Test plan
- [x] Add `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets
- [x] `docker compose up -d` on a clean checkout pulls the image and starts successfully
- [x] Push a test tag (e.g. `v0.0.1-test`) and confirm the workflow builds + pushes both `linux/amd64` and `linux/arm64` manifests